### PR TITLE
Fixes the body index used for computing end-effector Jacobian

### DIFF
--- a/source/extensions/omni.isaac.orbit/config/extension.toml
+++ b/source/extensions/omni.isaac.orbit/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.2.2"
+version = "0.2.3"
 
 # Description
 title = "ORBIT framework for Robot Learning"

--- a/source/extensions/omni.isaac.orbit/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.orbit/docs/CHANGELOG.rst
@@ -7,7 +7,7 @@ Changelog
 Fixed
 ^^^^^
 
-* Fixed the end-effector body index used for getting Jacobian in the :class:`SingleArm` class.
+* Fixed the end-effector body index used for getting the Jacobian in the :class:`SingleArm` and :class:`MobileManipulator` classes.
 
 
 0.2.2 (2023-01-27)

--- a/source/extensions/omni.isaac.orbit/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.orbit/docs/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 ---------
 
+0.2.3 (2023-02-24)
+~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed the end-effector body index used for getting Jacobian in the :class:`SingleArm` class.
+
+
 0.2.2 (2023-01-27)
 ~~~~~~~~~~~~~~~~~~
 

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/robots/mobile_manipulator/mobile_manipulator.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/robots/mobile_manipulator/mobile_manipulator.py
@@ -97,7 +97,9 @@ class MobileManipulator(SingleArmManipulator):
         # jacobian
         if self.cfg.data_info.enable_jacobian:
             jacobians = self.articulations.get_jacobians(indices=self._ALL_INDICES, clone=False)
-            self._data.ee_jacobian[:] = jacobians[:, self.ee_body_index, :, self.base_num_dof : self.arm_num_dof]
+            # Returned jacobian: [batch, body, 6, dof] does not include the base body (i.e. the first link).
+            # So we need to subtract 1 from the body index to get the correct jacobian.
+            self._data.ee_jacobian[:] = jacobians[:, self.ee_body_index - 1, :, self.base_num_dof : self.arm_num_dof]
         # mass matrix
         if self.cfg.data_info.enable_mass_matrix:
             mass_matrices = self.articulations.get_mass_matrices(indices=self._ALL_INDICES, clone=False)

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/robots/single_arm/single_arm.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/robots/single_arm/single_arm.py
@@ -150,11 +150,11 @@ class SingleArmManipulator(RobotBase):
         super()._process_info_cfg()
         # resolve regex expressions for indices
         # -- end-effector body
-        self.ee_body_index = None
+        self.ee_body_index = -1
         for body_index, body_name in enumerate(self.body_names):
             if re.fullmatch(self.cfg.ee_info.body_name, body_name):
                 self.ee_body_index = body_index
-        if self.ee_body_index is None:
+        if self.ee_body_index == -1:
             raise ValueError(f"Could not find end-effector body with name: {self.cfg.ee_info.body_name}")
         # -- tool sites
         if self.cfg.meta_info.tool_sites_names:


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-orbit.github.io/orbit/source/refs/contributing.html
-->

The Jacobians returned from ArticulationView follow the shape: [batch, body, 6, dof]. However, it does not include the base body. For Franka Panda arm, this means:

```bash
jacob:  torch.Size([128, 10, 6, 9])
bodies:  ['panda_link0', 'panda_link1', 'panda_link2', 'panda_link3', 'panda_link4', 'panda_link5', 'panda_link6', 'panda_link7', 'panda_hand', 'panda_leftfinger', 'panda_rightfinger']
num_bodies:  11
num_dof: 9
```

Thus, we need to account for the base link when retrieving the Jacobian:

```python
self._data.ee_jacobian[:] = jacobians[:, self.ee_body_index - 1, :,  : self.arm_num_dof]
```

Fixes #21

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see [here](https://pre-commit.com/#install) instructions to set it up)
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
