### PR TITLE
Updates simulation flags for performance improvements

### DIFF
--- a/source/extensions/omni.isaac.orbit_envs/config/extension.toml
+++ b/source/extensions/omni.isaac.orbit_envs/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.2.0"
+version = "0.2.1"
 
 # Description
 title = "ORBIT Environments"

--- a/source/extensions/omni.isaac.orbit_envs/data/rsl_rl/cabinet_ppo.yaml
+++ b/source/extensions/omni.isaac.orbit_envs/data/rsl_rl/cabinet_ppo.yaml
@@ -46,7 +46,7 @@ runner:
 
   # logging
   save_interval: 50  # check for potential saves every this many iterations
-  experiment_name: "reach"
+  experiment_name: "cabinet"
   run_name: ""
   # load and resume
   resume: False

--- a/source/extensions/omni.isaac.orbit_envs/data/rsl_rl/cartpole_ppo.yaml
+++ b/source/extensions/omni.isaac.orbit_envs/data/rsl_rl/cartpole_ppo.yaml
@@ -37,7 +37,7 @@ runner:
 
   # logging
   save_interval: 50  # check for potential saves every this many iterations
-  experiment_name: "lift"
+  experiment_name: "cartpole"
   run_name: ""
   # load and resume
   resume: False

--- a/source/extensions/omni.isaac.orbit_envs/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.orbit_envs/docs/CHANGELOG.rst
@@ -1,6 +1,31 @@
 Changelog
 ---------
 
+0.2.1 (2023-03-01)
+~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Added a flag ``disable_contact_processing`` to the :class:`SimCfg` class to handle
+  contact processing effectively when using TensorAPIs for contact reporting.
+* Added verbosity flag to :meth:`export_policy_as_onnx` to print model summary.
+
+Fixed
+^^^^^
+
+* Clarified the documentation of flags in the :class:`SimCfg` class.
+* Added enabling of ``omni.kit.viewport`` and ``omni.replicator.isaac`` extensions
+  dynamically to maintain order in the startup of extensions.
+* Corrected the experiment names in the configuration files for training environments with ``rsl_rl``.
+
+Changed
+^^^^^^^
+
+* Changed the default value of ``enable_scene_query_support`` in :class:`SimCfg` class to False.
+  The flag is overridden to True inside :class:`IsaacEnv` class when running the simulation in
+  non-headless mode.
+
 0.2.0 (2023-01-25)
 ~~~~~~~~~~~~~~~~~~
 

--- a/source/extensions/omni.isaac.orbit_envs/omni/isaac/orbit_envs/isaac_env_cfg.py
+++ b/source/extensions/omni.isaac.orbit_envs/omni/isaac/orbit_envs/isaac_env_cfg.py
@@ -188,6 +188,15 @@ class SimCfg:
         When enabled, the GUI will not update the physics parameters in real-time. To enable real-time
         updates, please set this flag to :obj:`False`.
     """
+
+    disable_contact_processing: bool = False
+    """Enable/disable contact processing. Default is False.
+
+    By default, the physics engine processes all the contacts in the scene. However, reporting this contact
+    information can be expensive due to its combinatorial complexity. This flag allows disabling the contact
+    processing and querying the contacts manually by the user over a limited set of primitives in the scene.
+
+    It is recommended to set this flag to :obj:`True` when using the TensorAPIs for contact reporting.
     """
 
     use_gpu_pipeline: bool = True

--- a/source/extensions/omni.isaac.orbit_envs/omni/isaac/orbit_envs/isaac_env_cfg.py
+++ b/source/extensions/omni.isaac.orbit_envs/omni/isaac/orbit_envs/isaac_env_cfg.py
@@ -151,31 +151,49 @@ class SimCfg:
     gravity: Tuple[float, float, float] = (0.0, 0.0, -9.81)
     """The gravity vector (in m/s^2). Default is (0.0, 0.0, -9.81)."""
 
-    enable_scene_query_support: bool = True
-    """Enable/disable scene query support when using instanced assets. Default is True.
+    enable_scene_query_support: bool = False
+    """Enable/disable scene query support for collision shapes. Default is False.
 
-    If this is set to False, the geometries of instances assets will appear stationary. However, this
-    can also provide some performance speed-up.
+    This flag allows performing collision queries (raycasts, sweeps, and overlaps) on actors and
+    attached shapes in the scene. This is useful for implementing custom collision detection logic
+    outside of the physics engine.
+
+    If set to False, the physics engine does not create the scene query manager and the scene query
+    functionality will not be available. However, this provides some performance speed-up.
+
+    Note:
+        This flag is overridden to True inside the :class:`IsaacEnv` class when running the simulation
+        with the GUI enabled. This is to allow certain GUI features to work properly.
     """
 
     replicate_physics: bool = True
     """Enable/disable replication of physics schemas when using the Cloner APIs. Default is False.
 
-    Note: In Isaac Sim 2022.2.0, domain randomization of material properties is not supported when
-    ``replicate_physics`` is set to True.
+    Note:
+        In Isaac Sim 2022.2.0, domain randomization of material properties is not supported when
+        ``replicate_physics`` is set to True.
     """
 
-    use_flatcache: bool = True  # output from simulation to flat cache
+    use_flatcache: bool = True
     """Enable/disable reading of physics buffers directly. Default is True.
 
-    If this is set to False, the physics buffers will be read from USD, which leads to overhead with
-    massive parallelization.
+    When running the simulation, updates in the states in the scene is normally synchronized with USD.
+    This leads to an overhead in reading the data and does not scale well with massive parallelization.
+    This flag allows disabling the synchronization and reading the data directly from the physics buffers.
+
+    It is recommended to set this flag to :obj:`True` when running the simulation with a large number
+    of primitives in the scene.
+
+    Note:
+        When enabled, the GUI will not update the physics parameters in real-time. To enable real-time
+        updates, please set this flag to :obj:`False`.
+    """
     """
 
     use_gpu_pipeline: bool = True
     """Enable/disable GPU pipeline. Default is True.
 
-    If this is set to False, the physics data will be read as CPU buffers.
+    If set to False, the physics data will be read as CPU buffers.
     """
 
     device: str = "cuda:0"

--- a/source/extensions/omni.isaac.orbit_envs/omni/isaac/orbit_envs/utils/wrappers/rsl_rl.py
+++ b/source/extensions/omni.isaac.orbit_envs/omni/isaac/orbit_envs/utils/wrappers/rsl_rl.py
@@ -172,17 +172,18 @@ def export_policy_as_jit(actor_critic: object, path: str, filename="policy.pt"):
     policy_exporter.export(path, filename)
 
 
-def export_policy_as_onnx(actor_critic: object, path: str, filename="policy.onnx"):
+def export_policy_as_onnx(actor_critic: object, path: str, filename="policy.onnx", verbose=False):
     """Export policy into a Torch ONNX file.
 
     Args:
         actor_critic (object): The actor-critic torch module.
         path (str): The path to the saving directory.
         filename (str, optional): The name of exported JIT file. Defaults to "policy.pt".
+        verbose (bool, optional): Whether to print the model summary. Defaults to False.
     """
     if not os.path.exists(path):
         os.makedirs(path, exist_ok=True)
-    policy_exporter = _OnnxPolicyExporter(actor_critic)
+    policy_exporter = _OnnxPolicyExporter(actor_critic, verbose)
     policy_exporter.export(path, filename)
 
 
@@ -239,8 +240,9 @@ class _TorchPolicyExporter(torch.nn.Module):
 class _OnnxPolicyExporter(torch.nn.Module):
     """Exporter of actor-critic into ONNX file."""
 
-    def __init__(self, actor_critic):
+    def __init__(self, actor_critic, verbose=False):
         super().__init__()
+        self.verbose = verbose
         self.actor = copy.deepcopy(actor_critic.actor)
         self.is_recurrent = actor_critic.is_recurrent
         if self.is_recurrent:
@@ -269,7 +271,7 @@ class _OnnxPolicyExporter(torch.nn.Module):
                 os.path.join(path, filename),
                 export_params=True,
                 opset_version=11,
-                verbose=True,
+                verbose=self.verbose,
                 input_names=["obs", "h_in", "c_in"],
                 output_names=["actions", "h_out", "c_out"],
                 dynamic_axes={},
@@ -282,7 +284,7 @@ class _OnnxPolicyExporter(torch.nn.Module):
                 os.path.join(path, filename),
                 export_params=True,
                 opset_version=11,
-                verbose=True,
+                verbose=self.verbose,
                 input_names=["obs"],
                 output_names=["actions"],
                 dynamic_axes={},


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-orbit.github.io/orbit/source/refs/contributing.html
-->

This PR makes some improvements to the `IsaacEnv` class for reducing loading time and improving performance.

* Fixes enabling the viewport when running in the non-headless viewport
* Starts the viewport and replicator extensions dynamically to follow the recommended loading order
* Adds flags to use [dispatcher](https://nvidia-omniverse.github.io/PhysX/physx/5.1.3/_build/physx/latest/class_px_cpu_dispatcher.html) from PhysX SDK instead of Carb
* Adds a flag to SimCfg to disable contact processing to enable efficient contact reporting through TensorAPIs

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see [here](https://pre-commit.com/#install) instructions to set it up)
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
