### PR TITLE
Separate the installation of pre-commit to -f|--format case

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -40,7 +40,7 @@ To upload images to a PR -- simply drag and drop an image while in edit mode and
 
 ## Checklist
 
-- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see [here](https://pre-commit.com/#install) instructions to set it up)
+- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./orbit.sh --format`
 - [ ] I have made corresponding changes to the documentation
 - [ ] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works

--- a/docs/source/refs/contributing.rst
+++ b/docs/source/refs/contributing.rst
@@ -76,7 +76,7 @@ following command in the terminal:
 
 .. code:: bash
 
-   pre-commit run --all-files
+   ./orbit.sh --format
 
 Maintaining a changelog
 -----------------------

--- a/docs/source/setup/developer.rst
+++ b/docs/source/setup/developer.rst
@@ -248,4 +248,4 @@ To run over the entire repository, please execute the following command in the t
 
 .. code:: bash
 
-   pre-commit run --all-files
+   ./orbit.sh --format

--- a/orbit.sh
+++ b/orbit.sh
@@ -149,7 +149,10 @@ while [[ $# -gt 0 ]]; do
                 pip install pre-commit
             fi
             echo "[INFO] Formatting the repository..."
+            # always execute inside the Orbit directory
+            cd "${ORBIT_PATH}"
             pre-commit run --all-files
+            cd -
             shift # past argument
             # exit neatly
             break

--- a/orbit.sh
+++ b/orbit.sh
@@ -110,8 +110,6 @@ while [[ $# -gt 0 ]]; do
             # this does not check dependencies between extensions
             export -f extract_isaacsim_python
             export -f install_orbit_extension
-            # initialize git hooks
-            pip install pre-commit
             # source directory
             find -L "${ORBIT_PATH}/source/extensions" -mindepth 1 -maxdepth 1 -type d -exec bash -c 'install_orbit_extension "{}"' \;
             # unset local variables
@@ -146,6 +144,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         # run the formatter over the repository
         -f|--format)
+            if ! command -v pre-commit &>/dev/null; then
+                echo "[INFO] Installing pre-commit..."
+                pip install pre-commit
+            fi
             echo "[INFO] Formatting the repository..."
             pre-commit run --all-files
             shift # past argument


### PR DESCRIPTION
# Description

This PR separates the installation of `pre-commit` from the main installation via `orbit.sh -i|--install` into the already existing `-f|--format` case.

This means that end-users are no longer required to install `pre-commit` when using the included `orbit.sh -i|--install` option, which should simplify the Dockerfile layers (#17). 

With this PR, `pre-commit` is automatically installed with `orbit.sh -f|--format` option if its command is not detected on the system. Furthermore, this PR makes sure that `pre-commit run` is always executed in the correct directory regardless of `${PWD}` when calling  `orbit.sh -f|--format` . Contributors are already informed to run pre-commit via the PR checklist found in the template (as seen below).

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see [here](https://pre-commit.com/#install) instructions to set it up)
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
