### PR TITLE
Fix minor typos in the documentation

### DIFF
--- a/docs/source/api/orbit.actuators.model.rst
+++ b/docs/source/api/orbit.actuators.model.rst
@@ -16,7 +16,7 @@ apply into the simulation. This process comprise of three main steps:
 2. :func:`compute_torque`: Compute the joint efforts using the actuator model.
 3. :func:`clip_torques`: Clip the desired torques epxlicitly using an actuator saturation model.
 
-It is upto the model how the input values from step (1) are processed and dealt with in step (2).
+It is up to the model how the input values from step (1) are processed and dealt with in step (2).
 The steps (2) and (3) are segregrated explicitly, since many times in learning, we need both the
 computed (desired) or clipped (applied) joint efforts. For instance, to penalize the difference
 between the computed and clipped joint efforts, so that the learned policy does not keep outputting

--- a/docs/source/features/motion_generators.rst
+++ b/docs/source/features/motion_generators.rst
@@ -217,7 +217,7 @@ We currently support the following planners:
 
 -  **MPC (OCS2):** A receding horizon control policy based on sequential linear-quadratic (SLQ) programming.
    It formulates various constraints into a single optimization problem via soft-penalties and uses automatic
-   differentiation to compute derivatives of the system dynamics, constriants and costs. Currently, we support
+   differentiation to compute derivatives of the system dynamics, constraints and costs. Currently, we support
    the MPC formulation for end-effector trajectory tracking in fixed-arm and mobile manipulators. The formulation
    considers a kinematic system model with joint limits and self-collision avoidance :cite:p:`mittal2021articulated`.
 

--- a/docs/source/setup/developer.rst
+++ b/docs/source/setup/developer.rst
@@ -139,7 +139,7 @@ It may also contains the ``scripts`` directory for keeping python-based applicat
 that are loaded into Omniverse when then extension is enabled using the
 `Extension Manager <https://docs.omniverse.nvidia.com/prod_extensions/prod_extensions/ext_extension-manager.html>`__.
 
-More specificially, when an extension is enabled, the python module specified in the
+More specifically, when an extension is enabled, the python module specified in the
 ``config/extension.toml`` file is loaded and scripts that contains children of the
 :class:`omni.ext.IExt` class are executed.
 

--- a/docs/source/setup/developer.rst
+++ b/docs/source/setup/developer.rst
@@ -209,7 +209,7 @@ class.
 
    from omni.isaac.core.simulation_context import SimulationContext
 
-   if __init__ == "__main__":
+   if __name__ == "__main__":
       # get simulation context
       simulation_context = SimulationContext()
       # rest and play simulation

--- a/docs/source/tutorials/01_arms.rst
+++ b/docs/source/tutorials/01_arms.rst
@@ -31,7 +31,7 @@ Designing the simulation scene
 ------------------------------
 
 The single arm manipulators refer to robotic arms with a fixed base. These robots are at the ground height, i.e. `z=0`.
-Accordingly, the robots areplaced on a table that define their workspace. In this tutorial, we spawn two robots on two
+Accordingly, the robots are placed on a table that define their workspace. In this tutorial, we spawn two robots on two
 different tables. The first robot is placed on the left table ``/World/Table_1`` and the second robot is placed on the
 right table ``/World/Table_2``.
 

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/actuators/model/actuator_physics.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/actuators/model/actuator_physics.py
@@ -255,7 +255,7 @@ class DCMotor(IdealActuator):
 class VariableGearRatioDCMotor(DCMotor):
     r"""Torque-controlled actuator with variable gear-ratio based saturation model.
 
-    Instead of using a fixed gear box, some motors are equiped with variators that allow the gear-ratio
+    Instead of using a fixed gear box, some motors are equipped with variators that allow the gear-ratio
     to be changed continuously (instead of steps). This model implements a DC motor with a variable
     gear ratio function that computes the gear-ratio as a function of the joint position, i.e.:
 

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/utils/math.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/utils/math.py
@@ -352,7 +352,7 @@ def combine_frame_transforms(
     r"""Combine transformations between two reference frames into a stationary frame.
 
     It performs the following transformation operation: :math:`T_{02} = T_{01} \times T_{12}`,
-    where :math:`T_{AB}` is the homogenous transformation matrix from frame A to B.
+    where :math:`T_{AB}` is the homogeneous transformation matrix from frame A to B.
 
     Args:
         t01 (torch.Tensor): Position of frame 1 w.r.t. frame 0.
@@ -385,7 +385,7 @@ def subtract_frame_transforms(
     r"""Subtract transformations between two reference frames into a stationary frame.
 
     It performs the following transformation operation: :math:`T_{12} = T_{01}^{-1} \times T_{02}`,
-    where :math:`T_{AB}` is the homogenous transformation matrix from frame A to B.
+    where :math:`T_{AB}` is the homogeneous transformation matrix from frame A to B.
 
     Args:
         t01 (torch.Tensor): Position of frame 1 w.r.t. frame 0.


### PR DESCRIPTION
# Description

This PR fixes minor typos in the documentation. It also fixes a small mistake in the documentation for executing specific code when a Python script is run (as seen below).

```diff
- if __init__ == "__main__":
+ if __name__ == "__main__":
```

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see [here](https://pre-commit.com/#install) instructions to set it up)
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
