### PR TITLE
Simplifies setting of physics material on prims

### DIFF
--- a/source/extensions/omni.isaac.orbit/config/extension.toml
+++ b/source/extensions/omni.isaac.orbit/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.2.3"
+version = "0.2.4"
 
 # Description
 title = "ORBIT framework for Robot Learning"

--- a/source/extensions/omni.isaac.orbit/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.orbit/docs/CHANGELOG.rst
@@ -1,6 +1,22 @@
 Changelog
 ---------
 
+0.2.4 (2023-03-04)
+~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Added the :meth:`apply_physics_material` and :meth:`apply_nested_physics_material` to the ``omni.isaac.orbit.core.utils.kit``.
+* Added the :meth:`sample_cylinder` to sample points from a cylinder's surface.
+* Added documentation about the issue in using instanceable asset as markers.
+
+Fixed
+^^^^^
+
+* Simplified the physics material application in the rigid object and legged robot classes.
+
+
 0.2.3 (2023-02-24)
 ~~~~~~~~~~~~~~~~~~
 

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/objects/rigid/rigid_object_cfg.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/objects/rigid/rigid_object_cfg.py
@@ -19,11 +19,6 @@ class RigidObjectCfg:
 
         usd_path: str = MISSING
         """USD file to spawn asset from."""
-        geom_prim_rel_path: str = MISSING
-        """Relative path to the collision geom from the default prim in the USD file.
-
-        This is used to apply physics material to the rigid body.
-        """
         scale: Tuple[float, float, float] = (1.0, 1.0, 1.0)
         """Scale to spawn the object with. Defaults to (1.0, 1.0, 1.0)."""
 
@@ -41,17 +36,17 @@ class RigidObjectCfg:
         """Disable gravity for the actor. Defaults to False."""
 
     @configclass
-    class PhysicsMaterialPropertiesCfg:
-        """Properties to apply to the rigid body."""
+    class PhysicsMaterialCfg:
+        """Physics material applied to the rigid object."""
 
-        static_friction: Optional[float] = 0.5
-        """Static friction for the rigid body. Defaults to 0.5."""
-        dynamic_friction: Optional[float] = 0.5
-        """Dynamic friction for the rigid body. Defaults to 0.5."""
-        restitution: Optional[float] = 0.0
-        """Restitution for the rigid body. Defaults to 0.0."""
-        material_path: Optional[str] = "/physics_material"
-        """Relative path to spawn the material for the rigid body. Defaults to "/physics_material"."""
+        prim_path: str = "/World/Materials/rigidMaterial"
+        """Path to the physics material prim. Default: /World/Materials/rigidMaterial."""
+        static_friction: float = 0.5
+        """Static friction coefficient. Defaults to 0.5."""
+        dynamic_friction: float = 0.5
+        """Dynamic friction coefficient. Defaults to 0.5."""
+        restitution: float = 0.0
+        """Restitution coefficient. Defaults to 0.0."""
 
     @configclass
     class InitialStateCfg:
@@ -74,10 +69,13 @@ class RigidObjectCfg:
     ##
 
     meta_info: MetaInfoCfg = MetaInfoCfg()
-    """Meta-information about the rigid body."""
+    """Meta-information about the rigid object."""
     init_state: InitialStateCfg = InitialStateCfg()
-    """Initial state of the rigid body."""
+    """Initial state of the rigid object."""
     rigid_props: RigidBodyPropertiesCfg = RigidBodyPropertiesCfg()
-    """Properties to apply to the rigid body."""
-    material_props: PhysicsMaterialPropertiesCfg = PhysicsMaterialPropertiesCfg()
-    """Properties to apply to the physics material on the rigid body."""
+    """Properties to apply to all rigid bodies in the object."""
+    physics_material: Optional[PhysicsMaterialCfg] = PhysicsMaterialCfg()
+    """Settings for the physics material to apply to the rigid object.
+
+    If set to None, no physics material will be created and applied.
+    """

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/robots/legged_robot/legged_robot_cfg.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/robots/legged_robot/legged_robot_cfg.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from dataclasses import MISSING
-from typing import Dict, Tuple
+from typing import Dict, Optional, Tuple
 
 from omni.isaac.orbit.utils import configclass
 
@@ -48,5 +48,8 @@ class LeggedRobotCfg(RobotBaseCfg):
 
     The returned tensor for feet state is in the same order as that of the provided list.
     """
-    physics_material: PhysicsMaterialCfg = PhysicsMaterialCfg()
-    """Settings for the physics material to apply to feet."""
+    physics_material: Optional[PhysicsMaterialCfg] = PhysicsMaterialCfg()
+    """Settings for the physics material to apply to feet.
+
+    If set to None, no physics material will be created and applied.
+    """

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/utils/math.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/utils/math.py
@@ -586,3 +586,40 @@ def sample_uniform(
         size = (size,)
     # return tensor
     return torch.rand(*size, device=device) * (upper - lower) + lower
+
+
+def sample_cylinder(
+    radius: float, h_range: Tuple[float, float], size: Union[int, Tuple[int, ...]], device: str
+) -> torch.Tensor:
+    """Sample 3D points uniformly on a cylinder's surface.
+
+    The cylinder is centered at the origin and aligned with the z-axis. The height of the cylinder is
+    sampled uniformly from the range :obj:`h_range`, while the radius is fixed to :obj:`radius`.
+
+    The sampled points are returned as a tensor of shape :obj:`(*size, 3)`, i.e. the last dimension
+    contains the x, y, and z coordinates of the sampled points.
+
+    Args:
+        radius (float): The radius of the cylinder.
+        h_range (Tuple[float, float]): The minimum and maximum height of the cylinder.
+        size (Union[int, Tuple[int, ...]]): The shape of the tensor.
+        device (str): Device to create tensor on.
+
+    Returns:
+        torch.Tensor: Sampled tensor of shape :obj:`(*size, 3)`.
+    """
+    # sample angles
+    angles = (torch.rand(size, device=device) * 2 - 1) * np.pi
+    h_min, h_max = h_range
+    # add shape
+    if isinstance(size, int):
+        size = (size, 3)
+    else:
+        size += (3,)
+    # allocate a tensor
+    xyz = torch.zeros(size, device=device)
+    xyz[..., 0] = radius * torch.cos(angles)
+    xyz[..., 1] = radius * torch.sin(angles)
+    xyz[..., 2].uniform_(h_min, h_max)
+    # return positions
+    return xyz

--- a/source/extensions/omni.isaac.orbit_envs/config/extension.toml
+++ b/source/extensions/omni.isaac.orbit_envs/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.2.1"
+version = "0.2.2"
 
 # Description
 title = "ORBIT Environments"

--- a/source/extensions/omni.isaac.orbit_envs/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.orbit_envs/docs/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+0.2.2 (2023-03-04)
+~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed the issue with rigid object not working in the ``Isaac-Lift-Franka-v0`` environment.
+
 0.2.1 (2023-03-01)
 ~~~~~~~~~~~~~~~~~~
 

--- a/source/extensions/omni.isaac.orbit_envs/omni/isaac/orbit_envs/manipulation/lift/lift_cfg.py
+++ b/source/extensions/omni.isaac.orbit_envs/omni/isaac/orbit_envs/manipulation/lift/lift_cfg.py
@@ -31,7 +31,6 @@ class ManipulationObjectCfg(RigidObjectCfg):
 
     meta_info = RigidObjectCfg.MetaInfoCfg(
         usd_path=f"{ISAAC_NUCLEUS_DIR}/Props/Blocks/DexCube/dex_cube_instanceable.usd",
-        geom_prim_rel_path="/collisions",
         scale=(0.8, 0.8, 0.8),
     )
     init_state = RigidObjectCfg.InitialStateCfg(
@@ -43,8 +42,8 @@ class ManipulationObjectCfg(RigidObjectCfg):
         max_depenetration_velocity=10.0,
         disable_gravity=False,
     )
-    material_props = RigidObjectCfg.PhysicsMaterialPropertiesCfg(
-        static_friction=0.5, dynamic_friction=0.5, restitution=0.0, material_path="/physics_material"
+    physics_material = RigidObjectCfg.PhysicsMaterialCfg(
+        static_friction=0.5, dynamic_friction=0.5, restitution=0.0, prim_path="/World/Materials/cubeMaterial"
     )
 
 
@@ -53,9 +52,9 @@ class GoalMarkerCfg:
     """Properties for visualization marker."""
 
     # usd file to import
-    usd_path = f"{ISAAC_NUCLEUS_DIR}/Props/Blocks/DexCube/dex_cube_instanceable.usd"
+    usd_path = f"{ISAAC_NUCLEUS_DIR}/Props/UIElements/frame_prim.usd"
     # scale of the asset at import
-    scale = [0.8, 0.8, 0.8]  # x,y,z
+    scale = [0.05, 0.05, 0.05]  # x,y,z
 
 
 @configclass

--- a/source/standalone/demo/play_ycb_objects.py
+++ b/source/standalone/demo/play_ycb_objects.py
@@ -36,7 +36,7 @@ from omni.isaac.core.utils.viewports import set_camera_view
 import omni.isaac.orbit.utils.kit as kit_utils
 from omni.isaac.orbit.objects.rigid import RigidObject, RigidObjectCfg
 from omni.isaac.orbit.utils.assets import ISAAC_NUCLEUS_DIR
-from omni.isaac.orbit.utils.math import sample_cylinder, random_yaw_orientation, quat_mul, convert_quat
+from omni.isaac.orbit.utils.math import convert_quat, quat_mul, random_yaw_orientation, sample_cylinder
 
 """
 Helpers
@@ -93,7 +93,7 @@ def main():
         "mustardBottle": f"{ISAAC_NUCLEUS_DIR}/Props/YCB/Axis_Aligned_Physics/006_mustard_bottle.usd",
     }
     for key, usd_path in ycb_usd_paths.items():
-        translation = torch.rand(3,).tolist()
+        translation = torch.rand(3).tolist()
         prim_utils.create_prim(f"/World/Objects/{key}", usd_path=usd_path, translation=translation)
 
     # Setup rigid object

--- a/source/standalone/demo/play_ycb_objects.py
+++ b/source/standalone/demo/play_ycb_objects.py
@@ -1,0 +1,170 @@
+# Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES, ETH Zurich, and University of Toronto
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""
+This script demonstrates how to use the rigid objects class.
+"""
+
+"""Launch Isaac Sim Simulator first."""
+
+
+import argparse
+
+from omni.isaac.kit import SimulationApp
+
+# add argparse arguments
+parser = argparse.ArgumentParser("Welcome to Orbit: Omniverse Robotics Environments!")
+parser.add_argument("--headless", action="store_true", default=False, help="Force display off at all times.")
+args_cli = parser.parse_args()
+
+# launch omniverse app
+config = {"headless": args_cli.headless}
+simulation_app = SimulationApp(config)
+
+
+"""Rest everything follows."""
+
+import scipy.spatial.transform as tf
+import torch
+
+import omni.isaac.core.utils.prims as prim_utils
+from omni.isaac.core.simulation_context import SimulationContext
+from omni.isaac.core.utils.viewports import set_camera_view
+
+import omni.isaac.orbit.utils.kit as kit_utils
+from omni.isaac.orbit.objects.rigid import RigidObject, RigidObjectCfg
+from omni.isaac.orbit.utils.assets import ISAAC_NUCLEUS_DIR
+from omni.isaac.orbit.utils.math import sample_cylinder, random_yaw_orientation, quat_mul, convert_quat
+
+"""
+Helpers
+"""
+
+
+def design_scene():
+    """Add prims to the scene."""
+    # Ground-plane
+    kit_utils.create_ground_plane(
+        "/World/defaultGroundPlane",
+        static_friction=0.5,
+        dynamic_friction=0.5,
+        restitution=0.8,
+        improve_patch_friction=True,
+    )
+    # Lights-1
+    prim_utils.create_prim(
+        "/World/Light/GreySphere",
+        "SphereLight",
+        translation=(4.5, 3.5, 10.0),
+        attributes={"radius": 2.5, "intensity": 600.0, "color": (0.75, 0.75, 0.75)},
+    )
+    # Lights-2
+    prim_utils.create_prim(
+        "/World/Light/WhiteSphere",
+        "SphereLight",
+        translation=(-4.5, 3.5, 10.0),
+        attributes={"radius": 2.5, "intensity": 600.0, "color": (1.0, 1.0, 1.0)},
+    )
+
+
+"""
+Main
+"""
+
+
+def main():
+    """Imports all legged robots supported in Orbit and applies zero actions."""
+
+    # Load kit helper
+    sim = SimulationContext(physics_dt=0.01, rendering_dt=0.01, backend="torch", device="cpu")
+    # Set main camera
+    set_camera_view(eye=[1.5, 1.5, 1.5], target=[0.0, 0.0, 0.0])
+
+    # Spawn things into stage
+    # design props
+    design_scene()
+    # add YCB objects
+    ycb_usd_paths = {
+        "crackerBox": f"{ISAAC_NUCLEUS_DIR}/Props/YCB/Axis_Aligned_Physics/003_cracker_box.usd",
+        "sugarBox": f"{ISAAC_NUCLEUS_DIR}/Props/YCB/Axis_Aligned_Physics/004_sugar_box.usd",
+        "tomatoSoupCan": f"{ISAAC_NUCLEUS_DIR}/Props/YCB/Axis_Aligned_Physics/005_tomato_soup_can.usd",
+        "mustardBottle": f"{ISAAC_NUCLEUS_DIR}/Props/YCB/Axis_Aligned_Physics/006_mustard_bottle.usd",
+    }
+    for key, usd_path in ycb_usd_paths.items():
+        translation = torch.rand(3,).tolist()
+        prim_utils.create_prim(f"/World/Objects/{key}", usd_path=usd_path, translation=translation)
+
+    # Setup rigid object
+    cfg = RigidObjectCfg()
+    # -- usd path
+    cfg.meta_info.usd_path = f"{ISAAC_NUCLEUS_DIR}/Props/YCB/Axis_Aligned_Physics/003_cracker_box.usd"
+    # -- rotate the object to align with the ground plane
+    cfg.init_state.rot = convert_quat(tf.Rotation.from_euler("XYZ", (-90, 90, 0), degrees=True).as_quat(), to="wxyz")
+
+    # Create rigid object handler
+    rigid_object = RigidObject(cfg)
+
+    # Spawn rigid object
+    # note: Spawning object like this will apply rigid object properties and physics material configurations.
+    rigid_object.spawn("/World/Objects/crackerBox2")
+
+    # Play the simulator
+    sim.reset()
+    # Initialize handles
+    # note: We desire view over all the objects in the scene.
+    rigid_object.initialize("/World/Objects/.*")
+
+    # Now we are ready!
+    print("[INFO]: Setup complete...")
+
+    # Define simulation stepping
+    sim_dt = sim.get_physics_dt()
+    sim_time = 0.0
+    count = 0
+    # Simulate physics
+    while simulation_app.is_running():
+        # If simulation is stopped, then exit.
+        if sim.is_stopped():
+            break
+        # If simulation is paused, then skip.
+        if not sim.is_playing():
+            sim.step(render=not args_cli.headless)
+            continue
+        # reset
+        if count % 250 == 0:
+            # reset counters
+            sim_time = 0.0
+            count = 0
+            # reset root state
+            root_state = rigid_object.get_default_root_state()
+            # -- position
+            root_state[:, :3] = sample_cylinder(
+                radius=0.5, h_range=(0.15, 0.25), size=rigid_object.count, device=rigid_object.device
+            )
+            # -- orientation: apply yaw rotation
+            root_state[:, 3:7] = quat_mul(
+                random_yaw_orientation(rigid_object.count, rigid_object.device), root_state[:, 3:7]
+            )
+            # -- set root state
+            rigid_object.set_root_state(root_state)
+            # reset buffers
+            rigid_object.reset_buffers()
+            print(">>>>>>>> Reset!")
+        # perform step
+        sim.step()
+        # update sim-time
+        sim_time += sim_dt
+        count += 1
+        # note: to deal with timeline events such as stopping, we need to check if the simulation is playing
+        if sim.is_playing():
+            # update buffers
+            rigid_object.update_buffers(sim_dt)
+
+
+if __name__ == "__main__":
+    # Run the main function
+    main()
+    # Close the simulator
+    simulation_app.close()


### PR DESCRIPTION
# Description

This PR fixes some inconsistencies in the API to apply physics materials over prims. Isaac Sim recommends using the `PhysicsMaterial` and `GeometryPrim` classes but these are not general enough to apply any physics material on any prim. The material binding API expects the prim to be physics-enabled to apply a material on it. Thus, the main contribution of the PR is to make this generic, s.t. if given a prim, one can search all prims under it and apply the physics material wherever possible. This simplifies the requirement of having `geom_prim_rel_path` as part of the `RigidObjectCfg`.

Other additions to this PR:
* A demo script to check the functionality of rigid object class with YCB objects
* Reporting an issue with using instanceable assets as markers
* Fixes #26 , #31

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./orbit.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
