### PR TITLE
Fixes rewards for Lift-Franka environment

### DIFF
--- a/source/extensions/omni.isaac.orbit/config/extension.toml
+++ b/source/extensions/omni.isaac.orbit/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.2.4"
+version = "0.2.5"
 
 # Description
 title = "ORBIT framework for Robot Learning"

--- a/source/extensions/omni.isaac.orbit/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.orbit/docs/CHANGELOG.rst
@@ -1,6 +1,22 @@
 Changelog
 ---------
 
+0.2.5 (2023-03-06)
+~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Added the :class:`CollisionPropertiesCfg` to rigid/articulated object and robot base classes.
+* Added the :class:`PhysicsMaterialCfg` to the :class:`SingleArm` class for tool sites.
+
+Changed
+^^^^^^^
+
+* Changed the default control mode of the :obj:`PANDA_HAND_MIMIC_GROUP_CFG` to be from ``"v_abs"`` to ``"p_abs"``.
+  Using velocity control for the mimic group can cause the hand to move in a jerky manner.
+
+
 0.2.4 (2023-03-04)
 ~~~~~~~~~~~~~~~~~~
 

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/actuators/config/franka.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/actuators/config/franka.py
@@ -13,7 +13,7 @@ Actuator Groups.
 PANDA_HAND_MIMIC_GROUP_CFG = GripperActuatorGroupCfg(
     dof_names=["panda_finger_joint[1-2]"],
     model_cfg=ImplicitActuatorCfg(velocity_limit=0.2, torque_limit=200),
-    control_cfg=ActuatorControlCfg(command_types=["v_abs"], stiffness={".*": 1e5}, damping={".*": 1e3}),
+    control_cfg=ActuatorControlCfg(command_types=["p_abs"], stiffness={".*": 1e5}, damping={".*": 1e3}),
     mimic_multiplier={"panda_finger_joint.*": 1.0},
     speed=0.1,
     open_dof_pos=0.04,

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/objects/articulated/articulated_object.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/objects/articulated/articulated_object.py
@@ -133,6 +133,8 @@ class ArticulatedObject:
         # TODO: What if prim already exists in the stage and spawn isn't called?
         # apply rigid body properties
         kit_utils.set_nested_rigid_body_properties(prim_path, **self.cfg.rigid_props.to_dict())
+        # apply collision properties
+        kit_utils.set_nested_collision_properties(prim_path, **self.cfg.collision_props.to_dict())
         # articulation root settings
         kit_utils.set_articulation_properties(prim_path, **self.cfg.articulation_props.to_dict())
 

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/objects/articulated/articulated_object.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/objects/articulated/articulated_object.py
@@ -132,23 +132,9 @@ class ArticulatedObject:
 
         # TODO: What if prim already exists in the stage and spawn isn't called?
         # apply rigid body properties
-        kit_utils.set_nested_rigid_body_properties(
-            prim_path,
-            linear_damping=self.cfg.rigid_props.linear_damping,
-            angular_damping=self.cfg.rigid_props.angular_damping,
-            max_linear_velocity=self.cfg.rigid_props.max_linear_velocity,
-            max_angular_velocity=self.cfg.rigid_props.max_angular_velocity,
-            max_depenetration_velocity=self.cfg.rigid_props.max_depenetration_velocity,
-            disable_gravity=self.cfg.rigid_props.disable_gravity,
-            retain_accelerations=self.cfg.rigid_props.retain_accelerations,
-        )
+        kit_utils.set_nested_rigid_body_properties(prim_path, **self.cfg.rigid_props.to_dict())
         # articulation root settings
-        kit_utils.set_articulation_properties(
-            prim_path,
-            enable_self_collisions=self.cfg.articulation_props.enable_self_collisions,
-            solver_position_iteration_count=self.cfg.articulation_props.solver_position_iteration_count,
-            solver_velocity_iteration_count=self.cfg.articulation_props.solver_velocity_iteration_count,
-        )
+        kit_utils.set_articulation_properties(prim_path, **self.cfg.articulation_props.to_dict())
 
     def initialize(self, prim_paths_expr: Optional[str] = None):
         """Initializes the PhysX handles and internal buffers.

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/objects/articulated/articulated_object_cfg.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/objects/articulated/articulated_object_cfg.py
@@ -33,11 +33,12 @@ class ArticulatedObjectCfg:
         angular_damping: Optional[float] = None
         """Angular damping coefficient."""
         max_linear_velocity: Optional[float] = 1000.0
-        """Maximum linear velocity for rigid bodies. Defaults to 1000.0."""
+        """Maximum linear velocity for rigid bodies (in m/s). Defaults to 1000.0."""
         max_angular_velocity: Optional[float] = 1000.0
-        """Maximum angular velocity for rigid bodies. Defaults to 1000.0."""
+        """Maximum angular velocity for rigid bodies (in rad/s). Defaults to 1000.0."""
         max_depenetration_velocity: Optional[float] = 10.0
-        """Maximum depenetration velocity permitted to be introduced by the solver. Defaults to 10.0."""
+        """Maximum depenetration velocity permitted to be introduced by the solver (in m/s).
+        Defaults to 10.0."""
         disable_gravity: Optional[bool] = False
         """Disable gravity for the actor. Defaults to False."""
         retain_accelerations: Optional[bool] = None

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/objects/articulated/articulated_object_cfg.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/objects/articulated/articulated_object_cfg.py
@@ -45,6 +45,21 @@ class ArticulatedObjectCfg:
         """Carries over forces/accelerations over sub-steps."""
 
     @configclass
+    class CollisionPropertiesCfg:
+        """Properties to apply to all collisions in the articulation."""
+
+        collision_enabled: Optional[bool] = None
+        """Whether to enable or disable collisions."""
+        contact_offset: Optional[float] = None
+        """Contact offset for the collision shape."""
+        rest_offset: Optional[float] = None
+        """Rest offset for the collision shape."""
+        torsional_patch_radius: Optional[float] = None
+        """Radius of the contact patch for applying torsional friction."""
+        min_torsional_patch_radius: Optional[float] = None
+        """Minimum radius of the contact patch for applying torsional friction."""
+
+    @configclass
     class ArticulationRootPropertiesCfg:
         """Properties to apply to articulation."""
 
@@ -86,5 +101,7 @@ class ArticulatedObjectCfg:
     """Initial state of the articulated object."""
     rigid_props: RigidBodyPropertiesCfg = RigidBodyPropertiesCfg()
     """Properties to apply to all rigid bodies in the articulation."""
+    collision_props: CollisionPropertiesCfg = CollisionPropertiesCfg()
+    """Properties to apply to all collisions in the articulation."""
     articulation_props: ArticulationRootPropertiesCfg = ArticulationRootPropertiesCfg()
     """Properties to apply to articulation."""

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/objects/rigid/rigid_object.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/objects/rigid/rigid_object.py
@@ -110,13 +110,7 @@ class RigidObject:
         # apply rigid body properties API
         RigidPrim(prim_path=prim_path)
         # -- set rigid body properties
-        kit_utils.set_nested_rigid_body_properties(
-            prim_path,
-            max_linear_velocity=self.cfg.rigid_props.max_linear_velocity,
-            max_angular_velocity=self.cfg.rigid_props.max_angular_velocity,
-            max_depenetration_velocity=self.cfg.rigid_props.max_depenetration_velocity,
-            disable_gravity=self.cfg.rigid_props.disable_gravity,
-        )
+        kit_utils.set_nested_rigid_body_properties(prim_path, **self.cfg.rigid_props.to_dict())
         # create physics material
         if self.cfg.physics_material is not None:
             # -- resolve material path

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/objects/rigid/rigid_object.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/objects/rigid/rigid_object.py
@@ -111,6 +111,8 @@ class RigidObject:
         RigidPrim(prim_path=prim_path)
         # -- set rigid body properties
         kit_utils.set_nested_rigid_body_properties(prim_path, **self.cfg.rigid_props.to_dict())
+        # apply collision properties
+        kit_utils.set_nested_collision_properties(prim_path, **self.cfg.collision_props.to_dict())
         # create physics material
         if self.cfg.physics_material is not None:
             # -- resolve material path

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/objects/rigid/rigid_object_cfg.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/objects/rigid/rigid_object_cfg.py
@@ -26,6 +26,10 @@ class RigidObjectCfg:
     class RigidBodyPropertiesCfg:
         """Properties to apply to the rigid body."""
 
+        solver_position_iteration_count: Optional[int] = None
+        """Solver position iteration counts for the body."""
+        solver_velocity_iteration_count: Optional[int] = None
+        """Solver position iteration counts for the body."""
         max_linear_velocity: Optional[float] = 1000.0
         """Maximum linear velocity for rigid bodies. Defaults to 1000.0."""
         max_angular_velocity: Optional[float] = 1000.0

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/objects/rigid/rigid_object_cfg.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/objects/rigid/rigid_object_cfg.py
@@ -31,11 +31,12 @@ class RigidObjectCfg:
         solver_velocity_iteration_count: Optional[int] = None
         """Solver position iteration counts for the body."""
         max_linear_velocity: Optional[float] = 1000.0
-        """Maximum linear velocity for rigid bodies. Defaults to 1000.0."""
+        """Maximum linear velocity for rigid bodies (in m/s). Defaults to 1000.0."""
         max_angular_velocity: Optional[float] = 1000.0
-        """Maximum angular velocity for rigid bodies. Defaults to 1000.0."""
+        """Maximum angular velocity for rigid bodies (in rad/s). Defaults to 1000.0."""
         max_depenetration_velocity: Optional[float] = 10.0
-        """Maximum depenetration velocity permitted to be introduced by the solver. Defaults to 10.0."""
+        """Maximum depenetration velocity permitted to be introduced by the solver (in m/s).
+        Defaults to 10.0."""
         disable_gravity: Optional[bool] = False
         """Disable gravity for the actor. Defaults to False."""
 

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/objects/rigid/rigid_object_cfg.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/objects/rigid/rigid_object_cfg.py
@@ -41,6 +41,21 @@ class RigidObjectCfg:
         """Disable gravity for the actor. Defaults to False."""
 
     @configclass
+    class CollisionPropertiesCfg:
+        """Properties to apply to all collisions in the articulation."""
+
+        collision_enabled: Optional[bool] = None
+        """Whether to enable or disable collisions."""
+        contact_offset: Optional[float] = None
+        """Contact offset for the collision shape."""
+        rest_offset: Optional[float] = None
+        """Rest offset for the collision shape."""
+        torsional_patch_radius: Optional[float] = None
+        """Radius of the contact patch for applying torsional friction."""
+        min_torsional_patch_radius: Optional[float] = None
+        """Minimum radius of the contact patch for applying torsional friction."""
+
+    @configclass
     class PhysicsMaterialCfg:
         """Physics material applied to the rigid object."""
 
@@ -84,6 +99,8 @@ class RigidObjectCfg:
     """Initial state of the rigid object."""
     rigid_props: RigidBodyPropertiesCfg = RigidBodyPropertiesCfg()
     """Properties to apply to all rigid bodies in the object."""
+    collision_props: CollisionPropertiesCfg = CollisionPropertiesCfg()
+    """Properties to apply to all collisions in the articulation."""
     physics_material: Optional[PhysicsMaterialCfg] = PhysicsMaterialCfg()
     """Settings for the physics material to apply to the rigid object.
 

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/robots/config/anymal.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/robots/config/anymal.py
@@ -90,6 +90,10 @@ ANYMAL_B_CFG = LeggedRobotCfg(
         max_angular_velocity=1000.0,
         max_depenetration_velocity=1.0,
     ),
+    collision_props=LeggedRobotCfg.CollisionPropertiesCfg(
+        contact_offset=0.02,
+        rest_offset=0.0,
+    ),
     articulation_props=LeggedRobotCfg.ArticulationRootPropertiesCfg(
         enable_self_collisions=True, solver_position_iteration_count=4, solver_velocity_iteration_count=1
     ),
@@ -140,6 +144,10 @@ ANYMAL_C_CFG = LeggedRobotCfg(
         max_linear_velocity=1000.0,
         max_angular_velocity=1000.0,
         max_depenetration_velocity=1.0,
+    ),
+    collision_props=LeggedRobotCfg.CollisionPropertiesCfg(
+        contact_offset=0.02,
+        rest_offset=0.0,
     ),
     articulation_props=LeggedRobotCfg.ArticulationRootPropertiesCfg(
         enable_self_collisions=True, solver_position_iteration_count=4, solver_velocity_iteration_count=1

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/robots/config/franka.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/robots/config/franka.py
@@ -40,12 +40,19 @@ FRANKA_PANDA_ARM_WITH_PANDA_HAND_CFG = SingleArmManipulatorCfg(
             "panda_joint5": 0.0,
             "panda_joint6": 3.037,
             "panda_joint7": 0.741,
-            "panda_finger_joint*": 0.035,
+            "panda_finger_joint*": 0.04,
         },
         dof_vel={".*": 0.0},
     ),
     ee_info=SingleArmManipulatorCfg.EndEffectorFrameCfg(
         body_name="panda_hand", pos_offset=(0.0, 0.0, 0.1034), rot_offset=(1.0, 0.0, 0.0, 0.0)
+    ),
+    rigid_props=SingleArmManipulatorCfg.RigidBodyPropertiesCfg(
+        max_depenetration_velocity=5.0,
+    ),
+    collision_props=SingleArmManipulatorCfg.CollisionPropertiesCfg(
+        contact_offset=0.005,
+        rest_offset=0.0,
     ),
     actuator_groups={
         "panda_shoulder": ActuatorGroupCfg(

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/robots/config/franka.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/robots/config/franka.py
@@ -54,6 +54,9 @@ FRANKA_PANDA_ARM_WITH_PANDA_HAND_CFG = SingleArmManipulatorCfg(
         contact_offset=0.005,
         rest_offset=0.0,
     ),
+    articulation_props=SingleArmManipulatorCfg.ArticulationRootPropertiesCfg(
+        enable_self_collisions=True,
+    ),
     actuator_groups={
         "panda_shoulder": ActuatorGroupCfg(
             dof_names=["panda_joint[1-4]"],

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/robots/config/unitree.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/robots/config/unitree.py
@@ -54,6 +54,10 @@ UNITREE_A1_CFG = LeggedRobotCfg(
         max_angular_velocity=1000.0,
         max_depenetration_velocity=1.0,
     ),
+    collision_props=LeggedRobotCfg.CollisionPropertiesCfg(
+        contact_offset=0.02,
+        rest_offset=0.0,
+    ),
     articulation_props=LeggedRobotCfg.ArticulationRootPropertiesCfg(
         enable_self_collisions=True, solver_position_iteration_count=4, solver_velocity_iteration_count=1
     ),

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/robots/legged_robot/legged_robot.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/robots/legged_robot/legged_robot.py
@@ -62,8 +62,6 @@ class LeggedRobot(RobotBase):
     def spawn(self, prim_path: str, translation: Sequence[float] = None, orientation: Sequence[float] = None):
         # spawn the robot and set its location
         super().spawn(prim_path, translation, orientation)
-        # alter physics collision properties
-        kit_utils.set_nested_collision_properties(prim_path, contact_offset=0.02, rest_offset=0.0)
         # add physics material to the feet bodies!
         if self.cfg.physics_material is not None:
             # -- resolve material path

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/robots/robot_base_cfg.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/robots/robot_base_cfg.py
@@ -44,6 +44,21 @@ class RobotBaseCfg:
         """Carries over forces/accelerations over sub-steps."""
 
     @configclass
+    class CollisionPropertiesCfg:
+        """Properties to apply to all collisions in the articulation."""
+
+        collision_enabled: Optional[bool] = None
+        """Whether to enable or disable collisions."""
+        contact_offset: Optional[float] = None
+        """Contact offset for the collision shape."""
+        rest_offset: Optional[float] = None
+        """Rest offset for the collision shape."""
+        torsional_patch_radius: Optional[float] = None
+        """Radius of the contact patch for applying torsional friction."""
+        min_torsional_patch_radius: Optional[float] = None
+        """Minimum radius of the contact patch for applying torsional friction."""
+
+    @configclass
     class ArticulationRootPropertiesCfg:
         """Properties to apply to articulation."""
 
@@ -85,6 +100,8 @@ class RobotBaseCfg:
     """Initial state of the robot."""
     rigid_props: RigidBodyPropertiesCfg = RigidBodyPropertiesCfg()
     """Properties to apply to all rigid bodies in the articulation."""
+    collision_props: CollisionPropertiesCfg = CollisionPropertiesCfg()
+    """Properties to apply to all collisions in the articulation."""
     articulation_props: ArticulationRootPropertiesCfg = ArticulationRootPropertiesCfg()
     """Properties to apply to articulation."""
     actuator_groups: Dict[str, ActuatorGroupCfg] = MISSING

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/robots/robot_base_cfg.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/robots/robot_base_cfg.py
@@ -33,11 +33,12 @@ class RobotBaseCfg:
         angular_damping: Optional[float] = None
         """Angular damping coefficient."""
         max_linear_velocity: Optional[float] = 1000.0
-        """Maximum linear velocity for rigid bodies. Defaults to 1000.0."""
+        """Maximum linear velocity for rigid bodies (in m/s). Defaults to 1000.0."""
         max_angular_velocity: Optional[float] = 1000.0
-        """Maximum angular velocity for rigid bodies. Defaults to 1000.0."""
+        """Maximum angular velocity for rigid bodies (in rad/s). Defaults to 1000.0."""
         max_depenetration_velocity: Optional[float] = 10.0
-        """Maximum depenetration velocity permitted to be introduced by the solver. Defaults to 10.0."""
+        """Maximum depenetration velocity permitted to be introduced by the solver (in m/s).
+        Defaults to 10.0."""
         disable_gravity: Optional[bool] = False
         """Disable gravity for the actor. Defaults to False."""
         retain_accelerations: Optional[bool] = None

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/robots/single_arm/single_arm_cfg.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/robots/single_arm/single_arm_cfg.py
@@ -56,6 +56,24 @@ class SingleArmManipulatorCfg(RobotBaseCfg):
         enable_gravity: bool = False
         """Fill in generalized gravity forces into data buffers. Defaults to False."""
 
+    @configclass
+    class PhysicsMaterialCfg:
+        """Physics material applied to the tool sites of the robot."""
+
+        prim_path = "/World/Materials/toolMaterial"
+        """Path to the physics material prim. Defaults to /World/Materials/toolMaterial.
+
+        Note:
+            If the prim path is not absolute, it will be resolved relative to the path specified when spawning
+            the object.
+        """
+        static_friction: float = 1.0
+        """Static friction coefficient. Defaults to 1.0."""
+        dynamic_friction: float = 1.0
+        """Dynamic friction coefficient. Defaults to 1.0."""
+        restitution: float = 0.0
+        """Restitution coefficient. Defaults to 0.0."""
+
     ##
     # Initialize configurations.
     ##
@@ -66,3 +84,5 @@ class SingleArmManipulatorCfg(RobotBaseCfg):
     """Information about the end-effector frame location."""
     data_info: DataInfoCfg = DataInfoCfg()
     """Information about what all data to read from simulator."""
+    physics_material: PhysicsMaterialCfg = PhysicsMaterialCfg()
+    """Physics material applied to the tool sites of the robot."""

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/utils/kit.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/utils/kit.py
@@ -322,14 +322,14 @@ def set_rigid_body_properties(
         solver_velocity_iteration_count (Optional[int]): Solver velocity iteration counts for the body.
         linear_damping (Optional[float]): Linear damping coefficient.
         angular_damping (Optional[float]): Angular damping coefficient.
-        max_linear_velocity (Optional[float]): Max allowable linear velocity for rigid body.
-        max_angular_velocity (Optional[float]): Max allowable angular velocity for rigid body.
+        max_linear_velocity (Optional[float]): Max allowable linear velocity for rigid body (in m/s).
+        max_angular_velocity (Optional[float]): Max allowable angular velocity for rigid body (in rad/s).
         sleep_threshold (Optional[float]): Mass-normalized kinetic energy threshold below which an actor
             may go to sleep.
         stabilization_threshold (Optional[float]): Mass-normalized kinetic energy threshold below which
             an actor may participate in stabilization.
         max_depenetration_velocity (Optional[float]): The maximum depenetration velocity permitted to
-            be introduced by the solver.
+            be introduced by the solver (in m/s).
         max_contact_impulse (Optional[float]): The limit on the impulse that may be applied at a contact.
         enable_gyroscopic_forces (Optional[bool]): Enables computation of gyroscopic forces on the
             rigid body.
@@ -408,12 +408,12 @@ def set_collision_properties(
     Args:
         prim_path (str): The prim path of parent.
         collision_enabled (Optional[bool], optional): Whether to enable/disable collider.
-        contact_offset (Optional[float], optional): Contact offset of a collision shape.
-        rest_offset (Optional[float], optional): Rest offset of a collision shape.
+        contact_offset (Optional[float], optional): Contact offset of a collision shape (in m).
+        rest_offset (Optional[float], optional): Rest offset of a collision shape (in m).
         torsional_patch_radius (Optional[float], optional): Defines the radius of the contact patch
-            used to apply torsional friction.
+            used to apply torsional friction (in m).
         min_torsional_patch_radius (Optional[float], optional): Defines the minimum radius of the
-            contact patch used to apply torsional friction.
+            contact patch used to apply torsional friction (in m).
 
     Raises:
         ValueError:  When no collision schema found at specified prim path.
@@ -536,14 +536,14 @@ def set_nested_rigid_body_properties(prim_path: str, **kwargs):
         solver_velocity_iteration_count (Optional[int]): Solver velocity iteration counts for the body.
         linear_damping (Optional[float]): Linear damping coefficient.
         angular_damping (Optional[float]): Angular damping coefficient.
-        max_linear_velocity (Optional[float]): Max allowable linear velocity for rigid body.
-        max_angular_velocity (Optional[float]): Max allowable angular velocity for rigid body.
+        max_linear_velocity (Optional[float]): Max allowable linear velocity for rigid body (in m/s).
+        max_angular_velocity (Optional[float]): Max allowable angular velocity for rigid body (in rad/s).
         sleep_threshold (Optional[float]): Mass-normalized kinetic energy threshold below which an actor
             may go to sleep.
         stabilization_threshold (Optional[float]): Mass-normalized kinetic energy threshold below which
             an actor may participate in stabilization.
         max_depenetration_velocity (Optional[float]): The maximum depenetration velocity permitted to
-            be introduced by the solver.
+            be introduced by the solver (in m/s).
         max_contact_impulse (Optional[float]): The limit on the impulse that may be applied at a contact.
         enable_gyroscopic_forces (Optional[bool]): Enables computation of gyroscopic forces on the
             rigid body.
@@ -575,12 +575,12 @@ def set_nested_collision_properties(prim_path: str, **kwargs):
 
     Keyword Args:
         collision_enabled (Optional[bool], optional): Whether to enable/disable collider.
-        contact_offset (Optional[float], optional): Contact offset of a collision shape.
-        rest_offset (Optional[float], optional): Rest offset of a collision shape.
+        contact_offset (Optional[float], optional): Contact offset of a collision shape (in m).
+        rest_offset (Optional[float], optional): Rest offset of a collision shape (in m).
         torsional_patch_radius (Optional[float], optional): Defines the radius of the contact patch
-            used to apply torsional friction.
+            used to apply torsional friction (in m).
         min_torsional_patch_radius (Optional[float], optional): Defines the minimum radius of the
-            contact patch used to apply torsional friction.
+            contact patch used to apply torsional friction (in m).
     """
     # get USD prim
     prim = prim_utils.get_prim_at_path(prim_path)

--- a/source/extensions/omni.isaac.orbit_envs/config/extension.toml
+++ b/source/extensions/omni.isaac.orbit_envs/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.2.2"
+version = "0.2.3"
 
 # Description
 title = "ORBIT Environments"

--- a/source/extensions/omni.isaac.orbit_envs/data/rl_games/lift_ppo.yaml
+++ b/source/extensions/omni.isaac.orbit_envs/data/rl_games/lift_ppo.yaml
@@ -49,18 +49,18 @@ params:
     mixed_precision: False
     normalize_input: True
     normalize_value: True
-    value_bootstrap: False
+    value_bootstrap: True
     num_actors: -1
     reward_shaper:
-      scale_value: 0.01
+      scale_value: 1.0
     normalize_advantage: True
     gamma: 0.99
     tau: 0.95
-    learning_rate: 3e-4
+    learning_rate: 5e-4
     lr_schedule: adaptive
     schedule_type: legacy
     kl_threshold: 0.008
-    score_to_win: 100000000
+    score_to_win: 10000
     max_epochs: 5000
     save_best_after: 200
     save_frequency: 100
@@ -69,9 +69,9 @@ params:
     entropy_coef: 0.0
     truncate_grads: True
     e_clip: 0.2
-    horizon_length: 16
+    horizon_length: 32
     minibatch_size: 2048
-    mini_epochs: 8
+    mini_epochs: 5
     critic_coef: 4
     clip_value: True
     seq_len: 4

--- a/source/extensions/omni.isaac.orbit_envs/data/rsl_rl/lift_ppo.yaml
+++ b/source/extensions/omni.isaac.orbit_envs/data/rsl_rl/lift_ppo.yaml
@@ -33,7 +33,7 @@ runner:
   policy_class_name: "ActorCritic"
   algorithm_class_name: "PPO"
   num_steps_per_env: 96  # per iteration
-  max_iterations: 1000  # number of policy updates
+  max_iterations: 700  # number of policy updates
 
   # logging
   save_interval: 50  # check for potential saves every this many iterations

--- a/source/extensions/omni.isaac.orbit_envs/data/rsl_rl/lift_ppo.yaml
+++ b/source/extensions/omni.isaac.orbit_envs/data/rsl_rl/lift_ppo.yaml
@@ -32,8 +32,8 @@ algorithm:
 runner:
   policy_class_name: "ActorCritic"
   algorithm_class_name: "PPO"
-  num_steps_per_env: 192  # per iteration
-  max_iterations: 1500  # number of policy updates
+  num_steps_per_env: 96  # per iteration
+  max_iterations: 1000  # number of policy updates
 
   # logging
   save_interval: 50  # check for potential saves every this many iterations

--- a/source/extensions/omni.isaac.orbit_envs/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.orbit_envs/docs/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+0.2.3 (2023-03-06)
+~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Tuned the observations and rewards for ``Isaac-Lift-Franka-v0`` environment.
+
 0.2.2 (2023-03-04)
 ~~~~~~~~~~~~~~~~~~
 

--- a/source/extensions/omni.isaac.orbit_envs/omni/isaac/orbit_envs/manipulation/lift/lift_cfg.py
+++ b/source/extensions/omni.isaac.orbit_envs/omni/isaac/orbit_envs/manipulation/lift/lift_cfg.py
@@ -37,8 +37,8 @@ class ManipulationObjectCfg(RigidObjectCfg):
         pos=(0.4, 0.0, 0.075), rot=(1.0, 0.0, 0.0, 0.0), lin_vel=(0.0, 0.0, 0.0), ang_vel=(0.0, 0.0, 0.0)
     )
     rigid_props = RigidObjectCfg.RigidBodyPropertiesCfg(
-        solver_position_iteration_count=8,
-        solver_velocity_iteration_count=0,
+        solver_position_iteration_count=16,
+        solver_velocity_iteration_count=1,
         max_angular_velocity=1000.0,
         max_linear_velocity=1000.0,
         max_depenetration_velocity=5.0,
@@ -86,8 +86,8 @@ class RandomizationCfg:
         position_cat: str = "default"  # randomize position: "default", "uniform"
         orientation_cat: str = "default"  # randomize position: "default", "uniform"
         # randomize position
-        position_uniform_min = [0.25, -0.25, 0.25]  # position (x,y,z)
-        position_uniform_max = [0.5, 0.25, 0.25]  # position (x,y,z)
+        position_uniform_min = [0.4, -0.25, 0.075]  # position (x,y,z)
+        position_uniform_max = [0.6, 0.25, 0.075]  # position (x,y,z)
 
     @configclass
     class ObjectDesiredPoseCfg:
@@ -98,8 +98,8 @@ class RandomizationCfg:
         orientation_cat: str = "default"  # randomize position: "default", "uniform"
         # randomize position
         position_default = [0.5, 0.0, 0.5]  # position default (x,y,z)
-        position_uniform_min = [0.25, -0.25, 0.25]  # position (x,y,z)
-        position_uniform_max = [0.5, 0.25, 0.5]  # position (x,y,z)
+        position_uniform_min = [0.4, -0.25, 0.25]  # position (x,y,z)
+        position_uniform_max = [0.6, 0.25, 0.5]  # position (x,y,z)
         # randomize orientation
         orientation_default = [1.0, 0.0, 0.0, 0.0]  # orientation default
 
@@ -120,15 +120,18 @@ class ObservationsCfg:
         enable_corruption: bool = True
         # observation terms
         # -- joint state
-        # arm_dof_pos_scaled = {"scale": 1.0, "noise": {"name": "uniform", "min": -0.01, "max": 0.01}}
-        arm_dof_vel = {"scale": 0.5, "noise": {"name": "uniform", "min": -0.1, "max": 0.1}}
+        arm_dof_pos = {"scale": 1.0}
+        # arm_dof_pos_scaled = {"scale": 1.0}
+        # arm_dof_vel = {"scale": 0.5, "noise": {"name": "uniform", "min": -0.01, "max": 0.01}}
         tool_dof_pos_scaled = {"scale": 1.0}
         # -- end effector state
         tool_positions = {"scale": 1.0}
         tool_orientations = {"scale": 1.0}
         # -- object state
-        object_relative_tool_positions = {"scale": 1.0}
+        # object_positions = {"scale": 1.0}
         # object_orientations = {"scale": 1.0}
+        object_relative_tool_positions = {"scale": 1.0}
+        # object_relative_tool_orientations = {"scale": 1.0}
         # -- object desired state
         object_desired_positions = {"scale": 1.0}
         # -- previous action
@@ -146,18 +149,20 @@ class ObservationsCfg:
 class RewardsCfg:
     """Reward terms for the MDP."""
 
-    # robot-centric
+    # -- robot-centric
     # reaching_object_position_l2 = {"weight": 0.0}
     # reaching_object_position_exp = {"weight": 2.5, "sigma": 0.25}
-    reaching_object_position_tanh = {"weight": 1.5, "sigma": 0.1}
+    reaching_object_position_tanh = {"weight": 2.5, "sigma": 0.1}
     # penalizing_arm_dof_velocity_l2 = {"weight": 1e-5}
     # penalizing_tool_dof_velocity_l2 = {"weight": 1e-5}
     # penalizing_robot_dof_acceleration_l2 = {"weight": 1e-7}
+    # -- action-centric
     penalizing_arm_action_rate_l2 = {"weight": 1e-2}
-    # object-centric
+    # penalizing_tool_action_l2 = {"weight": 1e-2}
+    # -- object-centric
     # tracking_object_position_exp = {"weight": 5.0, "sigma": 0.25, "threshold": 0.08}
-    tracking_object_position_tanh = {"weight": 5.0, "sigma": 0.1, "threshold": 0.08}
-    lifting_object_success = {"weight": 2.5, "threshold": 0.08}
+    tracking_object_position_tanh = {"weight": 5.0, "sigma": 0.2, "threshold": 0.08}
+    lifting_object_success = {"weight": 3.5, "threshold": 0.08}
 
 
 @configclass
@@ -197,7 +202,7 @@ class LiftEnvCfg(IsaacEnvCfg):
     """Configuration for the Lift environment."""
 
     # General Settings
-    env: EnvCfg = EnvCfg(num_envs=4096, env_spacing=2.5, episode_length_s=8.0)
+    env: EnvCfg = EnvCfg(num_envs=4096, env_spacing=2.5, episode_length_s=5.0)
     viewer: ViewerCfg = ViewerCfg(debug_vis=True, eye=(7.5, 7.5, 7.5), lookat=(0.0, 0.0, 0.0))
     # Physics settings
     sim: SimCfg = SimCfg(

--- a/source/extensions/omni.isaac.orbit_envs/omni/isaac/orbit_envs/manipulation/lift/lift_env.py
+++ b/source/extensions/omni.isaac.orbit_envs/omni/isaac/orbit_envs/manipulation/lift/lift_env.py
@@ -356,6 +356,10 @@ class LiftEnv(IsaacEnv):
 class LiftObservationManager(ObservationManager):
     """Reward manager for single-arm reaching environment."""
 
+    def arm_dof_pos(self, env: LiftEnv):
+        """DOF positions for the arm."""
+        return env.robot.data.arm_dof_pos
+
     def arm_dof_pos_scaled(self, env: LiftEnv):
         """DOF positions for the arm normalized to its max and min ranges."""
         return scale_transform(
@@ -427,6 +431,10 @@ class LiftObservationManager(ObservationManager):
 
     def tool_actions(self, env: LiftEnv):
         """Last tool actions provided to env."""
+        return env.actions[:, -1].unsqueeze(1)
+
+    def tool_actions_bool(self, env: LiftEnv):
+        """Last tool actions transformed to a boolean command."""
         return torch.sign(env.actions[:, -1]).unsqueeze(1)
 
 
@@ -469,8 +477,8 @@ class LiftRewardManager(RewardManager):
         return -torch.sum(torch.square(env.actions[:, :-1] - env.previous_actions[:, :-1]), dim=1)
 
     def penalizing_tool_action_l2(self, env: LiftEnv):
-        """Penalize large variations in action commands in the tool."""
-        return -torch.square(env.actions[:, -1] - env.previous_actions[:, -1])
+        """Penalize large values in action commands for the tool."""
+        return -torch.square(env.actions[:, -1])
 
     def tracking_object_position_exp(self, env: LiftEnv, sigma: float, threshold: float):
         """Penalize tracking object position error using exp-kernel."""

--- a/source/standalone/environments/state_machine/play_lift.py
+++ b/source/standalone/environments/state_machine/play_lift.py
@@ -1,0 +1,282 @@
+"""
+Script to run an environment with a pick and lift state machine.
+
+The state machine is implemented in the kernel function `infer_state_machine`.
+It uses the `warp` library to run the state machine in parallel on the GPU.
+
+Usage:
+    python play_lift.py --num_envs 128
+"""
+
+"""Launch Omniverse Toolkit first."""
+
+import argparse
+
+from omni.isaac.kit import SimulationApp
+
+# add argparse arguments
+parser = argparse.ArgumentParser("Welcome to Orbit: Omniverse Robotics Environments!")
+parser.add_argument("--headless", action="store_true", default=False, help="Force display off at all times.")
+parser.add_argument("--cpu", action="store_true", default=False, help="Use CPU pipeline.")
+parser.add_argument("--num_envs", type=int, default=None, help="Number of environments to simulate.")
+args_cli = parser.parse_args()
+
+# launch the simulator
+config = {"headless": args_cli.headless}
+simulation_app = SimulationApp(config)
+
+"""Rest everything else."""
+
+import gym
+import torch
+from enum import Enum
+from typing import Sequence, Union
+
+import warp as wp
+
+from omni.isaac.orbit.utils.timer import Timer
+
+import omni.isaac.orbit_envs  # noqa: F401
+from omni.isaac.orbit_envs.utils.parse_cfg import parse_env_cfg
+
+# initialize warp
+wp.init()
+
+
+class GripperState(Enum):
+    """States for the gripper."""
+
+    OPEN = wp.constant(1.0)
+    CLOSE = wp.constant(-1.0)
+
+
+class PickSmState(Enum):
+    """States for the pick state machine."""
+
+    REST = wp.constant(0)
+    APPROACH_ABOVE_OBJECT = wp.constant(1)
+    APPROACH_OBJECT = wp.constant(2)
+    GRASP_OBJECT = wp.constant(3)
+    LIFT_OBJECT = wp.constant(4)
+    DROP_OBJECT = wp.constant(5)
+
+
+class PickSmWaitTime(Enum):
+    """Additional wait times (in s) for states for before switching."""
+
+    REST = wp.constant(1.0)
+    APPROACH_ABOVE_OBJECT = wp.constant(0.5)
+    APPROACH_OBJECT = wp.constant(0.3)
+    GRASP_OBJECT = wp.constant(0.3)
+    LIFT_OBJECT = wp.constant(2.0)
+    DROP_OBJECT = wp.constant(0.2)
+
+
+@wp.kernel
+def infer_state_machine(
+    dt: wp.array(dtype=wp.float32),
+    sm_state: wp.array(dtype=wp.int32),
+    sm_wait_time: wp.array(dtype=wp.float32),
+    ee_pose: wp.array(dtype=wp.transform),
+    object_pose: wp.array(dtype=wp.transform),
+    des_object_pose: wp.array(dtype=wp.transform),
+    des_ee_pose: wp.array(dtype=wp.transform),
+    gripper_state: wp.array(dtype=wp.float32),
+    offset: wp.array(dtype=wp.transform),
+):
+    # retrieve thread id
+    tid = wp.tid()
+    # retrieve state machine state
+    state = sm_state[tid]
+    # decide next state
+    if state == PickSmState.REST.value:
+        des_ee_pose[tid] = ee_pose[tid]
+        gripper_state[tid] = GripperState.OPEN.value
+        # wait for a while
+        if sm_wait_time[tid] >= PickSmWaitTime.REST.value:
+            # move to next state and reset wait time
+            sm_state[tid] = PickSmState.APPROACH_ABOVE_OBJECT.value
+            sm_wait_time[tid] = 0.0
+    elif state == PickSmState.APPROACH_ABOVE_OBJECT.value:
+        des_ee_pose[tid] = object_pose[tid]
+        # TODO: This is causing issues.
+        # des_ee_pose[tid] = wp.transform_multiply(des_ee_pose[tid], offset[tid])
+        gripper_state[tid] = GripperState.OPEN.value
+        # TODO: error between current and desired ee pose below threshold
+        # wait for a while
+        if sm_wait_time[tid] >= PickSmWaitTime.APPROACH_OBJECT.value:
+            # move to next state and reset wait time
+            sm_state[tid] = PickSmState.APPROACH_OBJECT.value
+            sm_wait_time[tid] = 0.0
+    elif state == PickSmState.APPROACH_OBJECT.value:
+        des_ee_pose[tid] = object_pose[tid]
+        gripper_state[tid] = GripperState.OPEN.value
+        # TODO: error between current and desired ee pose below threshold
+        # wait for a while
+        if sm_wait_time[tid] >= PickSmWaitTime.APPROACH_OBJECT.value:
+            # move to next state and reset wait time
+            sm_state[tid] = PickSmState.GRASP_OBJECT.value
+            sm_wait_time[tid] = 0.0
+    elif state == PickSmState.GRASP_OBJECT.value:
+        des_ee_pose[tid] = object_pose[tid]
+        gripper_state[tid] = GripperState.CLOSE.value
+        # wait for a while
+        if sm_wait_time[tid] >= PickSmWaitTime.GRASP_OBJECT.value:
+            # move to next state and reset wait time
+            sm_state[tid] = PickSmState.LIFT_OBJECT.value
+            sm_wait_time[tid] = 0.0
+    elif state == PickSmState.LIFT_OBJECT.value:
+        des_ee_pose[tid] = des_object_pose[tid]
+        gripper_state[tid] = GripperState.CLOSE.value
+        # TODO: error between current and desired ee pose below threshold
+        # wait for a while
+        if sm_wait_time[tid] >= PickSmWaitTime.LIFT_OBJECT.value:
+            # move to next state and reset wait time
+            sm_state[tid] = PickSmState.DROP_OBJECT.value
+            sm_wait_time[tid] = 0.0
+    elif state == PickSmState.DROP_OBJECT.value:
+        des_ee_pose[tid] = des_object_pose[tid]
+        gripper_state[tid] = GripperState.OPEN.value
+        # wait for a while
+        if sm_wait_time[tid] >= PickSmWaitTime.DROP_OBJECT.value:
+            # move to next state and reset wait time
+            sm_state[tid] = PickSmState.REST.value
+            sm_wait_time[tid] = 0.0
+    # increment wait time
+    sm_wait_time[tid] = sm_wait_time[tid] + dt[tid]
+
+
+class PickAndLiftSm:
+    """A simple state machine in a robot's task space to pick and lift an object.
+
+    The state machine is implemented as a warp kernel. It takes in the current state of
+    the robot's end-effector and the object, and outputs the desired state of the robot's
+    end-effector and the gripper. The state machine is implemented as a finite state
+    machine with the following states:
+
+    1. REST: The robot is at rest.
+    2. APPROACH_ABOVE_OBJECT: The robot moves above the object.
+    3. APPROACH_OBJECT: The robot moves to the object.
+    4. GRASP_OBJECT: The robot grasps the object.
+    5. LIFT_OBJECT: The robot lifts the object.
+    6. DROP_OBJECT: The robot drops the object.
+    """
+
+    def __init__(self, dt: float, num_envs: int, device: Union[torch.device, str] = "cpu"):
+        """Initialize the state machine.
+
+        Args:
+            dt (float): The environment time step.
+            num_envs (int): The number of environments to simulate.
+            device (Union[torch.device, str], optional): The device to run the state machine on.
+        """
+        # save parameters
+        self.dt = dt
+        self.num_envs = num_envs
+        self.device = device
+        # initialize state machine
+        self.sm_dt = torch.full((self.num_envs,), self.dt, dtype=torch.float32, device=self.device)
+        self.sm_state = torch.full((self.num_envs,), 0, dtype=torch.int32, device=self.device)
+        self.sm_wait_time = torch.zeros((self.num_envs,), dtype=torch.float32, device=self.device)
+        # desired state
+        self.des_ee_pose = torch.zeros((self.num_envs, 7), dtype=torch.float32, device=self.device)
+        self.des_gripper_state = torch.full((self.num_envs,), 0, dtype=torch.float32, device=self.device)
+        # approach above object offset
+        self.offset = torch.zeros((self.num_envs, 7), dtype=torch.float32, device=self.device)
+        self.offset[:, 2] = 0.1
+        # convert to warp
+        self.sm_dt_wp = wp.from_torch(self.sm_dt, wp.float32)
+        self.sm_state_wp = wp.from_torch(self.sm_state, wp.int32)
+        self.sm_wait_time_wp = wp.from_torch(self.sm_wait_time, wp.float32)
+        self.des_ee_pose_wp = wp.from_torch(self.des_ee_pose, wp.transform)
+        self.des_gripper_state_wp = wp.from_torch(self.des_gripper_state, wp.float32)
+        self.offset_wp = wp.from_torch(self.offset, wp.transform)
+
+    def reset_idx(self, env_ids: Sequence[int] = None):
+        """Reset the state machine."""
+        if env_ids is None:
+            env_ids = ...
+        self.sm_state[env_ids] = 0
+        self.sm_wait_time[env_ids] = 0.0
+
+    def compute(self, ee_pose: torch.Tensor, object_pose: torch.Tensor, des_object_pose: torch.Tensor):
+        """Compute the desired state of the robot's end-effector and the gripper."""
+        # convert to warp
+        ee_pose_wp = wp.from_torch(ee_pose.contiguous(), wp.transform)
+        object_pose_wp = wp.from_torch(object_pose.contiguous(), wp.transform)
+        des_object_pose_wp = wp.from_torch(des_object_pose.contiguous(), wp.transform)
+        # run state machine
+        wp.launch(
+            kernel=infer_state_machine,
+            dim=self.num_envs,
+            inputs=[
+                self.sm_dt_wp,
+                self.sm_state_wp,
+                self.sm_wait_time_wp,
+                ee_pose_wp,
+                object_pose_wp,
+                des_object_pose_wp,
+                self.des_ee_pose_wp,
+                self.des_gripper_state_wp,
+                self.offset_wp,
+            ],
+        )
+        wp.synchronize()
+        # convert to torch
+        return torch.cat([self.des_ee_pose, self.des_gripper_state.unsqueeze(-1)], dim=-1)
+
+
+def main():
+    # parse configuration
+    env_cfg = parse_env_cfg("Isaac-Lift-Franka-v0", use_gpu=not args_cli.cpu, num_envs=args_cli.num_envs)
+    # -- control configuration
+    env_cfg.control.control_type = "inverse_kinematics"
+    env_cfg.control.inverse_kinematics.command_type = "position_abs"
+    # -- randomization configuration
+    env_cfg.randomization.object_initial_pose.position_cat = "uniform"
+    env_cfg.randomization.object_desired_pose.position_cat = "uniform"
+    # -- termination configuration
+    env_cfg.terminations.episode_timeout = False
+    # -- robot configuration
+    env_cfg.robot.robot_type = "franka"
+    # create environment
+    env = gym.make("Isaac-Lift-Franka-v0", cfg=env_cfg, headless=args_cli.headless)
+
+    # create action buffers
+    actions = torch.zeros((env.num_envs, env.action_space.shape[0]), device=env.device)
+    # create state machine
+    pick_sm = PickAndLiftSm(env.dt, env.num_envs, env.device)
+
+    # reset environment
+    env.reset()
+
+    # run state machine
+    for _ in range(10000):
+        # step environment
+        dones = env.step(actions)[-2]
+
+        # observations
+        ee_pose = env.robot.data.ee_state_w[:, :7].clone()
+        object_pose = env.object.data.root_state_w[:, :7].clone()
+        des_object_pose = env.object_des_pose_w.clone()
+        # transform from world to base frames
+        ee_pose[:, :3] -= env.robot.data.root_pos_w
+        object_pose[:, :3] -= env.robot.data.root_pos_w
+        des_object_pose[:, :3] -= env.robot.data.root_pos_w
+        # advance state machine
+        with Timer("state machine"):
+            sm_actions = pick_sm.compute(ee_pose, object_pose, des_object_pose)
+
+        # set actions for IK with positions
+        actions[:, :3] = sm_actions[:, :3]
+        actions[:, -1] = sm_actions[:, -1]
+        # reset state machine
+        if dones.any():
+            pick_sm.reset_idx(dones.nonzero(as_tuple=False).squeeze(-1))
+
+
+if __name__ == "__main__":
+    # run main function
+    main()
+    # close simulation
+    simulation_app.close()


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-orbit.github.io/orbit/source/refs/contributing.html
-->

This PR does the following:
* Adds collision properties as part of the robot class
* Simplifies calls for setting properties during the spawn() function
* Adds units in the documentation for properties
* Tunes observations and rewards for `Isaac-Lift-Franka-v0` environment: Training works with rsl_rl

Fixes #5 , #34

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Screenshots

I would not say the policy is deployable with current parameter tuning but at least it is better than what previously existed. We will need to investigate more on how to make the learned behavior more usable for sim-to-real.

```bash
./orbit.sh -p source/standalone/workflows/rsl_rl/train.py --task Isaac-Lift-Franka-v0 --headless --num_envs 4096
```

![train](https://user-images.githubusercontent.com/12863862/223256185-9c452978-bd3b-4774-8751-18fb7f0f3743.png)

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./orbit.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
