### PR TITLE
Fixes bug in math operation in `omni.isaac.orbit.utils.math`

### DIFF
--- a/source/extensions/omni.isaac.orbit/config/extension.toml
+++ b/source/extensions/omni.isaac.orbit/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.2.7"
+version = "0.2.8"
 
 # Description
 title = "ORBIT framework for Robot Learning"

--- a/source/extensions/omni.isaac.orbit/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.orbit/docs/CHANGELOG.rst
@@ -1,6 +1,16 @@
 Changelog
 ---------
 
+0.2.8 (2023-04-10)
+~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed bugs in :meth:`axis_angle_from_quat` in the ``omni.isaac.orbit.core.utils.math``.
+* Fixed bugs in :meth:`subtract_frame_transforms` in the ``omni.isaac.orbit.core.utils.math``.
+
+
 0.2.7 (2023-04-07)
 
 Fixed

--- a/source/extensions/omni.isaac.orbit/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.orbit/docs/CHANGELOG.rst
@@ -7,8 +7,8 @@ Changelog
 Fixed
 ^^^^^
 
-* Fixed bugs in :meth:`axis_angle_from_quat` in the ``omni.isaac.orbit.core.utils.math``.
-* Fixed bugs in :meth:`subtract_frame_transforms` in the ``omni.isaac.orbit.core.utils.math``.
+* Fixed bugs in :meth:`axis_angle_from_quat` in the ``omni.isaac.orbit.core.utils.math`` to handle quaternion with negative w component.
+* Fixed bugs in :meth:`subtract_frame_transforms` in the ``omni.isaac.orbit.core.utils.math`` by adding the missing final rotation.
 
 
 0.2.7 (2023-04-07)

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/utils/math.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/utils/math.py
@@ -329,7 +329,7 @@ def axis_angle_from_quat(quat: torch.Tensor, eps: float = 1.0e-6) -> torch.Tenso
     # Thus, axis-angle is [q_x, q_y, q_z] / (sin(theta/2) / theta)
     # When theta = 0, (sin(theta/2) / theta) is undefined
     # However, as theta --> 0, we can use the Taylor approximation 1/2 - theta^2 / 48
-
+    quat = quat * (1.0 - 2. * (quat[..., 0:1] < 0.0))
     mag = torch.linalg.norm(quat[..., 1:], dim=1)
     half_angle = torch.atan2(mag, quat[..., 0])
     angle = 2.0 * half_angle

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/utils/math.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/utils/math.py
@@ -398,10 +398,10 @@ def subtract_frame_transforms(
             frame 2 w.r.t. frame 1.
     """
     # compute orientation
-    q01_inv = quat_inv(q01)
-    q12 = quat_mul(q01_inv, q02)
+    q10 = quat_inv(q01)
+    q12 = quat_mul(q10, q02)
     # compute translation
-    t12 = quat_apply(q01_inv, t02 - t01)
+    t12 = quat_apply(q10, t02 - t01)
 
     return t12, q12
 

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/utils/math.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/utils/math.py
@@ -398,9 +398,10 @@ def subtract_frame_transforms(
             frame 2 w.r.t. frame 1.
     """
     # compute orientation
-    q12 = quat_mul(quat_inv(q01), q02)
+    q01_inv = quat_inv(q01)
+    q12 = quat_mul(q01_inv, q02)
     # compute translation
-    t12 = t02 - t01
+    t12 = quat_apply(q01_inv, t02 - t01)
 
     return t12, q12
 


### PR DESCRIPTION
# Description

<!--
Fixing two bugs in omni.isaac.orbit.core.utils.math


-->

Fixes bug in the math operations provided in `omni.isaac.orbit.utils.math` module:
* The `axis_angle_from_quat()` doesn't properly handle quaternion with a negative w component
* The `subtract_frame_transforms()` has a missing tf combine when calculating the translation part

Fixes #54



## Type of change

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./orbit.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file


