### PR TITLE
Add dataclass (configclass) decorator to DataInfoCfg

### DIFF
--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/robots/single_arm/single_arm_cfg.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/robots/single_arm/single_arm_cfg.py
@@ -41,6 +41,7 @@ class SingleArmManipulatorCfg(RobotBaseCfg):
         rot_offset: Tuple[float, float, float] = (1.0, 0.0, 0.0, 0.0)
         """Additional rotation offset ``(w, x, y, z)`` from the body frame. Defaults to (1, 0, 0, 0)."""
 
+    @configclass
     class DataInfoCfg:
         """Information about what all data to read from simulator.
 


### PR DESCRIPTION
# Description

This is a one line fix for a typo on the `DataInfoCfg` dataclass.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./orbit.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file

