### PR TITLE
Updates robomimic config for Franka-Lift environment

### DIFF
--- a/source/extensions/omni.isaac.orbit_envs/data/robomimic/lift_bc.json
+++ b/source/extensions/omni.isaac.orbit_envs/data/robomimic/lift_bc.json
@@ -143,7 +143,7 @@
                 "low_dim": [
                     "tool_dof_pos_scaled",
                     "tool_positions",
-                    "object_positions",
+                    "object_relative_tool_positions",
                     "object_desired_positions"
                 ],
                 "rgb": [],

--- a/source/extensions/omni.isaac.orbit_envs/data/robomimic/lift_bcq.json
+++ b/source/extensions/omni.isaac.orbit_envs/data/robomimic/lift_bcq.json
@@ -179,7 +179,7 @@
                 "low_dim": [
                     "tool_dof_pos_scaled",
                     "tool_positions",
-                    "object_positions",
+                    "object_relative_tool_positions",
                     "object_desired_positions"
                 ],
                 "rgb": [],

--- a/source/extensions/omni.isaac.orbit_envs/omni/isaac/orbit_envs/manipulation/lift/lift_env.py
+++ b/source/extensions/omni.isaac.orbit_envs/omni/isaac/orbit_envs/manipulation/lift/lift_env.py
@@ -183,7 +183,7 @@ class LiftEnv(IsaacEnv):
         self.extras["time_outs"] = self.episode_length_buf >= self.max_episode_length
         # -- add information to extra if task completed
         object_position_error = torch.norm(self.object.data.root_pos_w - self.object_des_pose_w[:, 0:3], dim=1)
-        self.extras["is_success"] = torch.where(object_position_error < 0.002, 1, self.reset_buf)
+        self.extras["is_success"] = torch.where(object_position_error < 0.02, 1, self.reset_buf)
         # -- update USD visualization
         if self.cfg.viewer.debug_vis and self.enable_render:
             self._debug_vis()
@@ -287,7 +287,7 @@ class LiftEnv(IsaacEnv):
         # -- when task is successful
         if self.cfg.terminations.is_success:
             object_position_error = torch.norm(self.object.data.root_pos_w - self.object_des_pose_w[:, 0:3], dim=1)
-            self.reset_buf = torch.where(object_position_error < 0.002, 1, self.reset_buf)
+            self.reset_buf = torch.where(object_position_error < 0.02, 1, self.reset_buf)
         # -- object fell off the table (table at height: 0.0 m)
         if self.cfg.terminations.object_falling:
             self.reset_buf = torch.where(object_pos[:, 2] < -0.05, 1, self.reset_buf)


### PR DESCRIPTION

# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-orbit.github.io/orbit/source/refs/contributing.html
-->

1. Enlarge the hard-coded success range from 0.002 to 0.02 so that it's possible for a human operator to succeed.
2. Update from `object_positions` to `object_relative_tool_positions` in [lift_bc.json](https://github.com/NVIDIA-Omniverse/Orbit/compare/main...yangcyself:Orbit:bugfix-68-mismatch-robomimic?expand=1#diff-9c052c38b3652ed4763c9e269b8a86c8b92c8689c0cd8afa58ca35e4c0dc605d) and [lift_bcq.json](https://github.com/NVIDIA-Omniverse/Orbit/compare/main...yangcyself:Orbit:bugfix-68-mismatch-robomimic?expand=1#diff-a6baabb6e1118ad88d5baff9048773db5899673d44a4831d03db613f7e020a00), to match with the configuration in [lift_cfg.py](https://github.com/NVIDIA-Omniverse/orbit/blob/6e6fa68e778d725d489a64068602e7c09d0b019e/source/extensions/omni.isaac.orbit_envs/omni/isaac/orbit_envs/manipulation/lift/lift_cfg.py)

Fixes #68 

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./orbit.sh --format`
- [ ] I have made corresponding changes to the documentation: Not applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works: Not applicable
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file: Not applicable
