### PR TITLE
Fixes setuptools==66.x to use gym==0.21.0

### DIFF
--- a/docs/source/refs/issues.rst
+++ b/docs/source/refs/issues.rst
@@ -1,6 +1,33 @@
 Known issues
 ============
 
+Installation errors due to gym==0.21.0
+--------------------------------------
+
+When installing the gym package, you may encounter the following error:
+
+.. code-block::
+
+    error in gym setup command: 'extras_require' must be a dictionary whose values are strings or lists of
+    strings containing valid project/version requirement specifiers.
+    ----------------------------------------
+    ERROR: Could not find a version that satisfies the requirement gym==0.21.0 (from omni-isaac-orbit-envs[all])
+    (from versions: 0.0.2, 0.0.3, 0.0.4, 0.0.5, 0.0.6, 0.0.7, 0.1.0, 0.1.1, 0.1.2, 0.1.3, 0.1.4, 0.1.5, 0.1.6,
+    ...
+    0.15.7, 0.16.0, 0.17.0, 0.17.1, 0.17.2, 0.17.3, 0.18.0, 0.18.3, 0.19.0, 0.20.0, 0.21.0, 0.22.0, 0.23.0,
+    0.23.1, 0.24.0, 0.24.1, 0.25.0, 0.25.1, 0.25.2, 0.26.0, 0.26.1, 0.26.2)
+    ERROR: No matching distribution found for gym==0.21.0
+
+
+This issue arises since the ``setuptools`` package from version 67.0 onwards does not support malformed version strings.
+Since the OpenAI Gym package that is no longer being maintained (`issue link <https://github.com/openai/gym/issues/3200>`_),
+the current workaround is to install the ``setuptools`` package version 66.0.0. You can do this by running the following
+command:
+
+.. code-block:: bash
+
+    ./orbit.sh -p -m pip install -U setuptools==66
+
 Regression in Isaac Sim 2022.2.1
 --------------------------------
 

--- a/source/extensions/omni.isaac.contrib_envs/setup.py
+++ b/source/extensions/omni.isaac.contrib_envs/setup.py
@@ -24,7 +24,7 @@ setup(
     description=EXTENSION_TOML_DATA["package"]["description"],
     keywords=EXTENSION_TOML_DATA["package"]["keywords"],
     include_package_data=True,
-    python_requires=">=3.7.*",
+    python_requires=">=3.7",
     packages=["omni.isaac.contrib_envs"],
     classifiers=["Natural Language :: English", "Programming Language :: Python :: 3.7"],
     zip_safe=False,

--- a/source/extensions/omni.isaac.orbit/setup.py
+++ b/source/extensions/omni.isaac.orbit/setup.py
@@ -37,7 +37,7 @@ setup(
     keywords=EXTENSION_TOML_DATA["package"]["keywords"],
     license="BSD-3-Clause",
     include_package_data=True,
-    python_requires=">=3.7.*",
+    python_requires=">=3.7",
     install_requires=INSTALL_REQUIRES,
     packages=["omni.isaac.orbit"],
     classifiers=["Natural Language :: English", "Programming Language :: Python :: 3.7"],

--- a/source/extensions/omni.isaac.orbit_envs/setup.py
+++ b/source/extensions/omni.isaac.orbit_envs/setup.py
@@ -26,13 +26,14 @@ INSTALL_REQUIRES = [
     # gym
     "gym==0.21.0",
     "importlib-metadata~=4.13.0",
+    "setuptools<=66"  # setuptools 67.0 breaks gym
     # data collection
     "h5py",
 ]
 
 # Extra dependencies for RL agents
 EXTRAS_REQUIRE = {
-    "sb3": ["stable-baselines3>=1.5.0", "tensorboard"],
+    "sb3": ["stable-baselines3>=1.5,<=1.8", "tensorboard"],
     "skrl": ["skrl>=0.10.0"],
     "rl_games": ["rl-games==1.5.2"],
     "rsl_rl": ["rsl_rl@git+https://github.com/leggedrobotics/rsl_rl.git"],
@@ -53,7 +54,7 @@ setup(
     description=EXTENSION_TOML_DATA["package"]["description"],
     keywords=EXTENSION_TOML_DATA["package"]["keywords"],
     include_package_data=True,
-    python_requires=">=3.7.*",
+    python_requires=">=3.7",
     install_requires=INSTALL_REQUIRES,
     extras_require=EXTRAS_REQUIRE,
     packages=["omni.isaac.orbit_envs"],


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-orbit.github.io/orbit/source/refs/contributing.html
-->

Setuptools 67.0 onwards does not support malformed strings. As mentioned in [their release notes](https://setuptools.pypa.io/en/latest/history.html#v67-0-0), users must conform to PEP specifications strictly (i.e. will result in build errors if not complied). To summarize they are:
* [PEP-440: Version Identification and Dependency Specification](https://peps.python.org/pep-0440/)
* [PEP 508 – Dependency specification for Python Software Packages](https://peps.python.org/pep-0508/)

This causes installation issues in Orbit while using the latest Python standard packages. Currently, Orbit uses OpenAI gym package v0.21.0 which is no longer being maintained.

The PR fixes the `setuptools` package version to be `<=66` so that the users can still continue using the `gym==0.21.0`. Though long-term we should switch to using Gymnasium. Additionally, it removes the malformed strings in Orbit packages to follow the new setuptools.

Fixes:
* https://forums.developer.nvidia.com/t/orbit-does-not-work-with-isaac-sim-2022-2-1/251572
* https://forums.developer.nvidia.com/t/isaac-orbit-installation-error/249626

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./orbit.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
