### PR TITLE
Added --install step before verification

### DIFF
--- a/docs/source/setup/installation.rst
+++ b/docs/source/setup/installation.rst
@@ -176,8 +176,17 @@ running the following on your terminal:
    # note: execute the command from where the `orbit.sh` executable exists
    # option1: for bash users
    echo -e "alias orbit=$(pwd)/orbit.sh" >> ${HOME}/.bashrc
+   source ${HOME}/.bashrc
+
    # option2: for zshell users
    echo -e "alias orbit=$(pwd)/orbit.sh" >> ${HOME}/.zshrc
+   source ${HOME}/.zshrc
+
+To finalize the installation, please run:
+
+.. code:: bash
+
+   orbit --install
 
 Setting up the environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
# Description

Added extra installation instructions to install orbit. This was report in #93 

## Type of change

- This change requires a documentation update

## Screenshots

| Before | After |
| ------ | ----- |
|  ![before](https://github.com/NVIDIA-Omniverse/Orbit/assets/6514550/724a9094-386a-4dac-b18a-6586e3536ee3) | ![after](https://github.com/NVIDIA-Omniverse/Orbit/assets/6514550/64adaca5-e06c-4acd-9c32-78a6a724bc8e) |

## Checklist

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./orbit.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file