### PR TITLE
Clear Instance of SimulationContext when closing environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,17 @@
 
 <!-- TODO: Replace docs status with workflow badge? Link: https://github.com/isaac-orbit/orbit/actions/workflows/docs.yaml/badge.svg -->
 
-Isaac Orbit (or *orbit* in short) is a unified and modular framework for robot learning powered by [NVIDIA Isaac Sim](https://docs.omniverse.nvidia.com/app_isaacsim/app_isaacsim/overview.html). It offers a modular design to easily and efficiently create robotic environments with photo-realistic scenes, and fast and accurate simulation.
+Isaac Orbit (or *orbit* in short) is a unified and modular framework for robot learning powered by [NVIDIA Isaac Sim](https://docs.omniverse.nvidia.com/app_isaacsim/app_isaacsim/overview.html). It offers a modular design to easily and efficiently create robotic environments with photo-realistic scenes and fast and accurate simulation.
 
-Please refer our [documentation page](https://isaac-orbit.github.io/orbit) to learn more about the installation steps, features and tutorials.
+Please refer to our [documentation page](https://isaac-orbit.github.io/orbit) to learn more about the installation steps, features, and tutorials.
+
+## ⚠️ Annoucement (22.09.2023)
+
+We are currently in a phase of heavy development, and our team is actively working on various aspects of the framework to enhance its modularity and overall functionality. We understand the anticipation for a new release and assure you that we are working diligently towards it. While we have yet to set an exact release date to share, we are targeting a release in early October 2023. We believe that the improvements we are making will be well worth the wait.
+
+For more details, please check the post here: https://github.com/NVIDIA-Omniverse/Orbit/discussions/106
+
+---
 
 ## Contributing to Orbit
 

--- a/docs/source/setup/installation.rst
+++ b/docs/source/setup/installation.rst
@@ -176,8 +176,17 @@ running the following on your terminal:
    # note: execute the command from where the `orbit.sh` executable exists
    # option1: for bash users
    echo -e "alias orbit=$(pwd)/orbit.sh" >> ${HOME}/.bashrc
+   source ${HOME}/.bashrc
+
    # option2: for zshell users
    echo -e "alias orbit=$(pwd)/orbit.sh" >> ${HOME}/.zshrc
+   source ${HOME}/.zshrc
+
+To finalize the installation, please run:
+
+.. code:: bash
+
+   orbit --install
 
 Setting up the environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/extensions/omni.isaac.orbit/config/extension.toml
+++ b/source/extensions/omni.isaac.orbit/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.3.2"
+version = "0.3.3"
 
 # Description
 title = "ORBIT framework for Robot Learning"

--- a/source/extensions/omni.isaac.orbit/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.orbit/docs/CHANGELOG.rst
@@ -7,7 +7,7 @@ Changelog
 Fixed
 ^^^^^
 
-* Fixed the closing of a `SimulationContext` instance in an `isaac_env.py` environment.
+* Fixed the closing of a `SimulationContext` instance in an ``isaac_env.py`` environment.
 
 
 0.3.2 (2023-04-27)

--- a/source/extensions/omni.isaac.orbit/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.orbit/docs/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 ---------
 
+0.3.3 (2023-09-25)
+~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed the closing of a `SimulationContext` instance in an `isaac_env.py` environment.
+
+
 0.3.2 (2023-04-27)
 ~~~~~~~~~~~~~~~~~~
 

--- a/source/extensions/omni.isaac.orbit_envs/omni/isaac/orbit_envs/isaac_env.py
+++ b/source/extensions/omni.isaac.orbit_envs/omni/isaac/orbit_envs/isaac_env.py
@@ -337,11 +337,11 @@ class IsaacEnv(gym.Env):
             # cleanup the scene and callbacks
             self.sim.clear_all_callbacks()
             self.sim.clear()
+            self.sim.clear_instance()
             # fix warnings at stage close
             omni.usd.get_context().get_stage().GetRootLayer().Clear()
             # update closing status
             self._is_closed = True
-        self.sim.__del__()
 
     """
     Implementation specifics.

--- a/source/extensions/omni.isaac.orbit_envs/omni/isaac/orbit_envs/isaac_env.py
+++ b/source/extensions/omni.isaac.orbit_envs/omni/isaac/orbit_envs/isaac_env.py
@@ -341,6 +341,7 @@ class IsaacEnv(gym.Env):
             omni.usd.get_context().get_stage().GetRootLayer().Clear()
             # update closing status
             self._is_closed = True
+        self.sim.__del__()
 
     """
     Implementation specifics.


### PR DESCRIPTION
# Description

In a context where an environment has to be closed and run again, this is not currently possible because the `SimulationContext` instance is not closed properly.

Fixes #118 (issue)

Minimum working example:

```
from omni.isaac.kit import SimulationApp
headless = True
simulation_app = SimulationApp({"headless": headless})

import gym
import omni.isaac.orbit_envs
from omni.isaac.orbit_envs.utils import parse_env_cfg


def main():
    task_name = "Isaac-Ant-v0"
    cfg_direct = parse_env_cfg(task_name, use_gpu=True, num_envs=8)

    idx = 1

    while True:
        print(f"STARTING ENV {idx}")
        env = gym.make(task_name, cfg=cfg_direct, headless=headless)

        env.close()
        print(f"CLOSING ENV {idx}")
        idx += 1

if __name__ == "__main__":
    main()
```

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./orbit.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
