### PR TITLE
[bug fix] fixed feet airtime calculation

### DIFF
--- a/docs/source/setup/installation.rst
+++ b/docs/source/setup/installation.rst
@@ -176,8 +176,17 @@ running the following on your terminal:
    # note: execute the command from where the `orbit.sh` executable exists
    # option1: for bash users
    echo -e "alias orbit=$(pwd)/orbit.sh" >> ${HOME}/.bashrc
+   source ${HOME}/.bashrc
+
    # option2: for zshell users
    echo -e "alias orbit=$(pwd)/orbit.sh" >> ${HOME}/.zshrc
+   source ${HOME}/.zshrc
+
+To finalize the installation, please run:
+
+.. code:: bash
+
+   orbit --install
 
 Setting up the environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/robots/legged_robot/legged_robot.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/robots/legged_robot/legged_robot.py
@@ -149,11 +149,11 @@ class LeggedRobot(RobotBase):
         # TODO: contact forces -- Waiting for contact sensors in IsaacSim.
         #   For now, use heuristics for flat terrain to say feet are in contact.
         # air times
-        # -- update ongoing timer for feet air
-        self._ongoing_feet_air_time += dt
         # -- check contact state of feet
         is_feet_contact = self._data.feet_state_w[:, :, 2] < 0.03
         is_feet_first_contact = (self._ongoing_feet_air_time > 0) * is_feet_contact
+        # -- update ongoing timer for feet air
+        self._ongoing_feet_air_time += dt
         # -- update buffers
         self._data.feet_air_time = self._ongoing_feet_air_time * is_feet_first_contact
         # -- reset timers for feet that are in contact for the first time

--- a/source/extensions/omni.isaac.orbit_envs/omni/isaac/orbit_envs/locomotion/velocity/velocity_env.py
+++ b/source/extensions/omni.isaac.orbit_envs/omni/isaac/orbit_envs/locomotion/velocity/velocity_env.py
@@ -521,8 +521,7 @@ class LocomotionVelocityRewardManager(RewardManager):
 
     def feet_air_time(self, env: VelocityEnv, time_threshold: float):
         """Reward long steps taken by the feet."""
-        first_contact = env.robot.data.feet_air_time > 0.0
-        reward = torch.sum((env.robot.data.feet_air_time - time_threshold) * first_contact, dim=1)
+        reward = torch.sum((env.robot.data.feet_air_time - time_threshold), dim=1)
         # no reward for zero command
         reward *= torch.norm(env.commands[:, :2], dim=1) > 0.1
         return reward


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-orbit.github.io/orbit/source/refs/contributing.html
-->

`self._ongoing_feet_air_time` should be incremented after calculating first contact, not before.

If incremented before, `is_feet_first_contact` will always be true, and thus always set `self._data.feet_air_time` to a minimum of `dt`, which in turn produces a reward of `dt`. We only want a reward upon actual first contact, not every contact.

Additionally, `first_contact` is not relevant when calculating the reward. This computation has already been done in `def update_buffers()`.


Also I see that feet airtime is calculated based on a heuristic of z height. Why don't we use `RigidContactView` for this? It is supported in Isaac 2022.2.0. I can implement this if desired.
https://github.com/NVIDIA-Omniverse/Orbit/blob/0d9ec72544024836d83c1a3a98e51e272a978204/source/extensions/omni.isaac.orbit/omni/isaac/orbit/robots/legged_robot/legged_robot.py#L155


<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)


## Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./orbit.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
