### PR TITLE
Fix camera __del__() method to also delete render products

### DIFF
--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sensors/camera/camera.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sensors/camera/camera.py
@@ -112,6 +112,9 @@ class Camera(SensorBase):
                 annotator.detach([render_product_path])
                 annotator = None
 
+        for render_product in self._render_products:
+            render_product.destroy()
+
     def __str__(self) -> str:
         """Returns: A string containing information about the instance."""
         # message for class
@@ -346,6 +349,7 @@ class Camera(SensorBase):
         # Attach the sensor data types to render node
         self._render_product_paths: list[str] = list()
         self._rep_registry: dict[str, list[rep.annotators.Annotator]] = {name: list() for name in self.cfg.data_types}
+        self._render_products: list = list()
         # Resolve device name
         if "cuda" in self._device:
             device_name = self._device.split(":")[0]
@@ -363,9 +367,12 @@ class Camera(SensorBase):
             self._sensor_prims.append(sensor_prim)
             # Get render product
             # From Isaac Sim 2023.1 onwards, render product is a HydraTexture so we need to extract the path
-            render_prod_path = rep.create.render_product(cam_prim_path, resolution=(self.cfg.width, self.cfg.height))
-            if not isinstance(render_prod_path, str):
-                render_prod_path = render_prod_path.path
+            render_prod = rep.create.render_product(cam_prim_path, resolution=(self.cfg.width, self.cfg.height))
+            self._render_products.append(render_prod)
+            if not isinstance(render_prod, str):
+                render_prod_path = render_prod.path
+            else:
+                render_prod_path = render_prod
             self._render_product_paths.append(render_prod_path)
             # Iterate over each data type and create annotator
             # TODO: This will move out of the loop once Replicator supports multiple render products within a single


### PR DESCRIPTION
# Description
Fixes a bug where `omni.isaac.orbit.sensors.Camera.__del__()` would not destroy the render products created.
During camera initialization, the render products are now saved to a list (similar to their paths). During deletion, this list is looped over and the `.destroy()` method is called on each render product.

Fixes #156 

See also [this forum discussion](https://forums.developer.nvidia.com/t/replicator-composer-memory-leak/271204/6?u=_jon).

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./orbit.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file

