### PR TITLE
fix bug in generating target_frame_body_names

### DIFF
--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sensors/frame_transformer/frame_transformer.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sensors/frame_transformer/frame_transformer.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import re
 import torch
 from typing import TYPE_CHECKING, Sequence
 
@@ -230,7 +231,7 @@ class FrameTransformer(SensorBase):
         first_env_prim_paths = all_prim_paths[0 : self._num_target_body_frames + 1]
         first_env_body_names = [first_env_prim_path.split("/")[-1] for first_env_prim_path in first_env_prim_paths]
 
-        target_frame_body_names = first_env_body_names[1:]
+        target_frame_body_names = [x for x in first_env_body_names if not re.match(self._tracked_body_names[0], x)]
 
         # The position and rotation components of target frame offsets
         target_frame_offset_pos = []


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-orbit.github.io/orbit/source/refs/contributing.html
-->

A fix on the target_frame_body_names. The original code might include the source frame instead since the frame order is not guaranteed to be preserved.

Fixes #170 


## Type of change


- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./orbit.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file

