### PR TITLE
Generalize command resampling

### DIFF
--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/commands/__init__.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/commands/__init__.py
@@ -5,6 +5,7 @@
 
 """Various command terms that can be used in the environment."""
 
+from . import resampling
 from .commands_cfg import (
     NormalVelocityCommandCfg,
     NullCommandCfg,

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/commands/commands_cfg.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/commands/commands_cfg.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-import math
 from dataclasses import MISSING
 
 from omni.isaac.orbit.managers import CommandTermCfg
@@ -26,11 +25,6 @@ class NullCommandCfg(CommandTermCfg):
     """Configuration for the null command generator."""
 
     class_type: type = NullCommand
-
-    def __post_init__(self):
-        """Post initialization."""
-        # set the resampling time range to infinity to avoid resampling
-        self.resampling_time_range = (math.inf, math.inf)
 
 
 """

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/commands/null_command.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/commands/null_command.py
@@ -28,7 +28,7 @@ class NullCommand(CommandTerm):
     def __str__(self) -> str:
         msg = "NullCommand:\n"
         msg += "\tCommand dimension: N/A\n"
-        msg += f"\tResampling time range: {self.cfg.resampling_time_range}"
+        msg += f"{self.cfg.resampling}"
         return msg
 
     """

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/commands/pose_command.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/commands/pose_command.py
@@ -70,7 +70,7 @@ class UniformPoseCommand(CommandTerm):
     def __str__(self) -> str:
         msg = "UniformPoseCommand:\n"
         msg += f"\tCommand dimension: {tuple(self.command.shape[1:])}\n"
-        msg += f"\tResampling time range: {self.cfg.resampling_time_range}\n"
+        msg += f"{self.cfg.resampling}"
         return msg
 
     """

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/commands/position_command.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/commands/position_command.py
@@ -62,8 +62,8 @@ class TerrainBasedPositionCommand(CommandTerm):
     def __str__(self) -> str:
         msg = "TerrainBasedPositionCommand:\n"
         msg += f"\tCommand dimension: {tuple(self.command.shape[1:])}\n"
-        msg += f"\tResampling time range: {self.cfg.resampling_time_range}\n"
         msg += f"\tStanding probability: {self.cfg.rel_standing_envs}"
+        msg += f"{self.cfg.resampling}"
         return msg
 
     """

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/commands/resampling/__init__.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/commands/resampling/__init__.py
@@ -4,4 +4,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from .fixed_frequency import FixedFrequency
-from .resampling_cfg import FixedFrequencyCfg
+from .random_chance import RandomChance
+from .resampling_cfg import FixedFrequencyCfg, RandomChanceCfg

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/commands/resampling/__init__.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/commands/resampling/__init__.py
@@ -4,3 +4,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from .fixed_frequency import FixedFrequency
+from .resampling_cfg import FixedFrequencyCfg

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/commands/resampling/__init__.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/commands/resampling/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2022-2024, The ORBIT Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from .fixed_frequency import FixedFrequency

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/commands/resampling/fixed_frequency.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/commands/resampling/fixed_frequency.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2022-2024, The ORBIT Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import torch
+from typing import Sequence
+
+from omni.isaac.orbit.managers import ResamplingTerm
+
+from .resampling_cfg import FixedFrequencyCfg
+
+
+class FixedFrequency(ResamplingTerm):
+    """Fixed frequency resampling term.
+
+    The fixed frequency resampling term is used to resample commands at a fixed frequency.
+    When an environment is resampled, the time left is sampled from the range specified
+    in the FixedFrequencyCfg.
+    """
+
+    def __init__(self, cfg: FixedFrequencyCfg, env):
+        super().__init__(cfg, env)
+
+        # -- time left before resampling
+        self.time_left = torch.zeros(self.num_envs, device=self.device)
+
+    def compute(self, dt: float):
+        """Compute the environment ids to be resampled.
+
+        Args:
+            dt: The time step.
+        """
+        # reduce the time left before resampling
+        self.time_left -= dt
+        # resample expired timers.
+        resample_env_ids = (self.time_left <= 0.0).nonzero().flatten()
+        return resample_env_ids
+
+    def reset(self, env_ids: Sequence[int]):
+        """Reset the resampling term.
+
+        Resamples the time left from the cfg range.
+
+        Args:
+            env_ids: The environment ids to be reset.
+        """
+        self.time_left[env_ids] = self.time_left[env_ids].uniform_(*self.cfg.resampling_time_range)

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/commands/resampling/fixed_frequency.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/commands/resampling/fixed_frequency.py
@@ -3,12 +3,15 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+from __future__ import annotations
+
 import torch
-from typing import Sequence
+from typing import TYPE_CHECKING, Sequence
 
 from omni.isaac.orbit.managers import ResamplingTerm
 
-from .resampling_cfg import FixedFrequencyCfg
+if TYPE_CHECKING:
+    from .resampling_cfg import FixedFrequencyCfg
 
 
 class FixedFrequency(ResamplingTerm):
@@ -24,6 +27,10 @@ class FixedFrequency(ResamplingTerm):
 
         # -- time left before resampling
         self.time_left = torch.zeros(self.num_envs, device=self.device)
+
+    def __str__(self) -> str:
+        msg = f"\t\tResampling time range: {self.cfg.resampling_time_range}"
+        return msg
 
     def compute(self, dt: float):
         """Compute the environment ids to be resampled.

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/commands/resampling/random_chance.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/commands/resampling/random_chance.py
@@ -36,5 +36,5 @@ class RandomChance(ResamplingTerm):
         """
         # Note: uniform_(0, 1) is inclusive on 0 and exclusive on 1. So we need to use < instead of <=.
         resample_prob_buf = torch.empty(self.num_envs, device=self.device).uniform_(0, 1) < self.cfg.resampling_probability
-        resample_prob_ids = resample_prob_buf.nonzero(as_tuple=False).flatten()
+        resample_env_ids = resample_prob_buf.nonzero(as_tuple=False).flatten()
         return resample_env_ids

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/commands/resampling/random_chance.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/commands/resampling/random_chance.py
@@ -25,7 +25,7 @@ class RandomChance(ResamplingTerm):
 
 
     def __str__(self) -> str:
-        msg = f"\t\tResampe probability: {self.cfg.resample_probability}"
+        msg = f"\t\tResampling probability: {self.cfg.resampling_probability}"
         return msg
 
     def compute(self, dt: float):
@@ -35,6 +35,6 @@ class RandomChance(ResamplingTerm):
             dt: The time step.
         """
         # Note: uniform_(0, 1) is inclusive on 0 and exclusive on 1. So we need to use < instead of <=.
-        resample_prob_buf = torch.empty(self.num_envs, device=self.device).uniform_(0, 1) < self.cfg.resample_probability
+        resample_prob_buf = torch.empty(self.num_envs, device=self.device).uniform_(0, 1) < self.cfg.resampling_probability
         resample_prob_ids = resample_prob_buf.nonzero(as_tuple=False).flatten()
         return resample_env_ids

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/commands/resampling/random_chance.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/commands/resampling/random_chance.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2022-2024, The ORBIT Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+import torch
+from typing import TYPE_CHECKING, Sequence
+
+from omni.isaac.orbit.managers import ResamplingTerm
+
+if TYPE_CHECKING:
+    from .resampling_cfg import RandomChanceCfg
+
+
+class RandomChance(ResamplingTerm):
+    """Random chance resampling term.
+
+    Commands are resampled with a fixed probability at every time step.
+    """
+
+    def __init__(self, cfg: FixedFrequencyCfg, env):
+        super().__init__(cfg, env)
+
+
+    def __str__(self) -> str:
+        msg = f"\t\tResampe probability: {self.cfg.resample_probability}"
+        return msg
+
+    def compute(self, dt: float):
+        """Compute the environment ids to be resampled.
+
+        Args:
+            dt: The time step.
+        """
+        # Note: uniform_(0, 1) is inclusive on 0 and exclusive on 1. So we need to use < instead of <=.
+        resample_prob_buf = torch.empty(self.num_envs, device=self.device).uniform_(0, 1) < self.cfg.resample_probability
+        resample_prob_ids = resample_prob_buf.nonzero(as_tuple=False).flatten()
+        return resample_env_ids

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/commands/resampling/random_chance.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/commands/resampling/random_chance.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 import torch
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING
 
 from omni.isaac.orbit.managers import ResamplingTerm
 
@@ -20,9 +20,8 @@ class RandomChance(ResamplingTerm):
     Commands are resampled with a fixed probability at every time step.
     """
 
-    def __init__(self, cfg: FixedFrequencyCfg, env):
+    def __init__(self, cfg: RandomChanceCfg, env):
         super().__init__(cfg, env)
-
 
     def __str__(self) -> str:
         msg = f"\t\tResampling probability: {self.cfg.resampling_probability}"
@@ -35,6 +34,8 @@ class RandomChance(ResamplingTerm):
             dt: The time step.
         """
         # Note: uniform_(0, 1) is inclusive on 0 and exclusive on 1. So we need to use < instead of <=.
-        resample_prob_buf = torch.empty(self.num_envs, device=self.device).uniform_(0, 1) < self.cfg.resampling_probability
+        resample_prob_buf = (
+            torch.empty(self.num_envs, device=self.device).uniform_(0, 1) < self.cfg.resampling_probability
+        )
         resample_env_ids = resample_prob_buf.nonzero(as_tuple=False).flatten()
         return resample_env_ids

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/commands/resampling/resampling_cfg.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/commands/resampling/resampling_cfg.py
@@ -10,6 +10,8 @@ from dataclasses import MISSING
 from omni.isaac.orbit.managers import ResamplingTermCfg
 from omni.isaac.orbit.utils import configclass
 
+from .fixed_frequency import FixedFrequency
+
 """
 Fixed frequency resampling term.
 """
@@ -18,5 +20,7 @@ Fixed frequency resampling term.
 @configclass
 class FixedFrequencyCfg(ResamplingTermCfg):
     """Configuration for the fixed frequency resampling term."""
+
+    class_type: type = FixedFrequency
 
     resampling_time_range: tuple[float, float] = MISSING

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/commands/resampling/resampling_cfg.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/commands/resampling/resampling_cfg.py
@@ -11,6 +11,7 @@ from omni.isaac.orbit.managers import ResamplingTermCfg
 from omni.isaac.orbit.utils import configclass
 
 from .fixed_frequency import FixedFrequency
+from .random_chance import RandomChance
 
 """
 Fixed frequency resampling term.
@@ -24,3 +25,17 @@ class FixedFrequencyCfg(ResamplingTermCfg):
     class_type: type = FixedFrequency
 
     resampling_time_range: tuple[float, float] = MISSING
+
+
+"""
+Random chance resampling term.
+"""
+
+
+@configclass
+class RandomChanceCfg(ResamplingTermCfg):
+    """Configuration for the fixed frequency resampling term."""
+
+    class_type: type = RandomChance
+
+    resample_probability: float = MISSING

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/commands/resampling/resampling_cfg.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/commands/resampling/resampling_cfg.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2022-2024, The ORBIT Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+from dataclasses import MISSING
+
+from omni.isaac.orbit.managers import ResamplingTermCfg
+from omni.isaac.orbit.utils import configclass
+
+"""
+Fixed frequency resampling term.
+"""
+
+
+@configclass
+class FixedFrequencyCfg(ResamplingTermCfg):
+    """Configuration for the fixed frequency resampling term."""
+
+    resampling_time_range: tuple[float, float] = MISSING

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/commands/resampling/resampling_cfg.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/commands/resampling/resampling_cfg.py
@@ -38,4 +38,4 @@ class RandomChanceCfg(ResamplingTermCfg):
 
     class_type: type = RandomChance
 
-    resample_probability: float = MISSING
+    resampling_probability: float = MISSING

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/managers/__init__.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/managers/__init__.py
@@ -22,11 +22,13 @@ from .manager_term_cfg import (
     ObservationGroupCfg,
     ObservationTermCfg,
     RandomizationTermCfg,
+    ResamplingTermCfg,
     RewardTermCfg,
     TerminationTermCfg,
 )
 from .observation_manager import ObservationManager
 from .randomization_manager import RandomizationManager
+from .resampling_manager import ResamplingManager, ResamplingTerm
 from .reward_manager import RewardManager
 from .scene_entity_cfg import SceneEntityCfg
 from .termination_manager import TerminationManager

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/managers/manager_term_cfg.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/managers/manager_term_cfg.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from .action_manager import ActionTerm
     from .command_manager import CommandTerm
     from .manager_base import ManagerTermBase
+    from .resampling_manager import ResamplingTerm
 
 
 @configclass
@@ -204,7 +205,7 @@ class RandomizationTermCfg(ManagerTermBaseCfg):
 class ResamplingTermCfg:
     """Configuration for a resampling term."""
 
-    class_type: type[CommandTerm] = MISSING
+    class_type: type[ResamplingTerm] = MISSING
     """The associated command term class to use.
 
     The class should inherit from :class:`omni.isaac.orbit.managers.resampling_manager.ResamplingTerm`.

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/managers/manager_term_cfg.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/managers/manager_term_cfg.py
@@ -87,8 +87,8 @@ class CommandTermCfg:
     The class should inherit from :class:`omni.isaac.orbit.managers.command_manager.CommandTerm`.
     """
 
-    resampling_time_range: tuple[float, float] = MISSING
-    """Time before commands are changed [s]."""
+    resampling: dict[str, ResamplingTermCfg] | None = None
+    """Terms used for resampling the command."""
     debug_vis: bool = False
     """Whether to visualize debug information. Defaults to False."""
 

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/managers/manager_term_cfg.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/managers/manager_term_cfg.py
@@ -196,6 +196,22 @@ class RandomizationTermCfg(ManagerTermBaseCfg):
 
 
 ##
+# Resampling manager.
+##
+
+
+@configclass
+class ResamplingTermCfg:
+    """Configuration for a resampling term."""
+
+    class_type: type[CommandTerm] = MISSING
+    """The associated command term class to use.
+
+    The class should inherit from :class:`omni.isaac.orbit.managers.resampling_manager.ResamplingTerm`.
+    """
+
+
+##
 # Reward manager.
 ##
 

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/managers/resampling_manager.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/managers/resampling_manager.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2022-2024, The ORBIT Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Resampling manager for resampling commands."""
+
+from __future__ import annotations
+
+import torch
+from abc import abstractmethod
+from typing import TYPE_CHECKING, Sequence
+
+import omni.kit.app
+
+from .manager_base import ManagerBase, ManagerTermBase
+from .manager_term_cfg import ResamplingTermCfg
+
+if TYPE_CHECKING:
+    from omni.isaac.orbit.envs import RLTaskEnv
+
+
+class ResamplingTerm(ManagerTermBase):
+    """The base class for implementing a resampling term.
+
+    A resampling term is used to decide whether a command should be resampled or not,
+    every time a command is updated. The terms are called by the resampling manager,
+    which in turn is called by the command term which owns it.
+    """
+
+    def __init__(self, cfg, env):
+        """Initialize the resampling term.
+
+        Args:
+            cfg: The configuration object.
+            env: The environment instance.
+        """
+        # initialize the base class
+        super().__init__(cfg, env)
+
+    @abstractmethod
+    def compute(self, dt: float):
+        """Compute the environment ids to be resampled.
+
+        Args:
+            dt: The time step.
+        """
+        # compute the resampling term
+        raise NotImplementedError
+
+    def reset(self, env_ids: Sequence[int]):
+        """Reset the resampling term.
+
+        Some resamplig terms need to know when their commands are resampled
+        (e.g. th FixedFrequency term needs to reset its time left counter).
+        Since a command term can have multiple resampling terms, it is not
+        possible to know for sure when the command is resampled. This function is
+        called by the command term when it resamples to ensure that all resampling
+        terms are properly reset.
+
+        Args:
+            env_ids: The environment ids to be reset.
+        """
+        pass
+
+
+class ResamplingManager(ManagerBase):
+    """Manager for resampling commands.
+
+    The resampling manager is used to determine whether a command should
+    be resampled or not. It will be owned by a CommandTerm, which calls
+    the resampling manager every time it computes a command, to decide
+    which environment ids should be resampled.
+
+    The manager consists of multiple reward terms. Every reward term is
+    called to get environment ids to be resampled. The union of these
+    ids are resampled by the CommandTerm.
+
+    Args:
+        cfg: The configuration object.
+        env: The environment instance.
+    """
+
+    _env: RLTaskEnv
+    """The environment instance."""
+
+    def __init__(self, cfg, env):
+        """Initialize the resampling manager.
+
+        Args:
+            cfg: The configuration object.
+            env: The environment instance.
+        """
+
+        # initialize the base class
+        super().__init__(cfg, env)
+
+    def compute(self, dt: float):
+        """Compute the environment ids to be resampled.
+
+        Calls all reward terms and returns the union of the environment ids.
+
+        Args:
+            dt: The time step since last computing the resampling ids.
+        """
+        env_ids = []
+        for term in self._terms.values():
+            env_ids.append(term.compute(dt).view(-1))
+
+        return torch.unique(torch.cat(env_ids))
+
+    def reset(self, env_ids: Sequence[int] | None = None):
+        """
+        Resets all resampling terms.
+
+        Args:
+            env_ids: The environment ids to be reset. If None, all the environments
+                are reset.
+        """
+        if env_ids is None:
+            env_ids = slice(None)
+
+        for term in self._terms.values():
+            term.reset(env_ids)
+
+    def _prepare_terms(self):
+        """Prepares a list of resampling terms."""
+        # parse command terms from the config
+        self._terms: dict[str, ResamplingTerm] = dict()
+
+        # check if config is dict already
+        if isinstance(self.cfg, dict):
+            cfg_items = self.cfg.items()
+        else:
+            cfg_items = self.cfg.__dict__.items()
+        # iterate over all the terms
+        for term_name, term_cfg in cfg_items:
+            # check for non config
+            if term_cfg is None:
+                continue
+            # check for valid config type
+            if not isinstance(term_cfg, ResamplingTermCfg):
+                raise TypeError(
+                    f"Configuration for the term '{term_name}' is not of type ResamplingTermCfg."
+                    f" Received: '{type(term_cfg)}'."
+                )
+            # create the action term
+            term = term_cfg.class_type(term_cfg, self._env)
+            # add class to dict
+            self._terms[term_name] = term

--- a/source/extensions/omni.isaac.orbit_tasks/omni/isaac/orbit_tasks/locomotion/velocity/velocity_env_cfg.py
+++ b/source/extensions/omni.isaac.orbit_tasks/omni/isaac/orbit_tasks/locomotion/velocity/velocity_env_cfg.py
@@ -11,6 +11,7 @@ from dataclasses import MISSING
 import omni.isaac.orbit.sim as sim_utils
 from omni.isaac.orbit.assets import ArticulationCfg, AssetBaseCfg
 from omni.isaac.orbit.envs import RLTaskEnvCfg
+from omni.isaac.orbit.envs.mdp.commands.resampling import FixedFrequencyCfg
 from omni.isaac.orbit.managers import CurriculumTermCfg as CurrTerm
 from omni.isaac.orbit.managers import ObservationGroupCfg as ObsGroup
 from omni.isaac.orbit.managers import ObservationTermCfg as ObsTerm
@@ -94,7 +95,7 @@ class CommandsCfg:
 
     base_velocity = mdp.UniformVelocityCommandCfg(
         asset_name="robot",
-        resampling_time_range=(10.0, 10.0),
+        resampling={"fixed_frequency": FixedFrequencyCfg(resampling_time_range=(10.0, 10.0))},
         rel_standing_envs=0.02,
         rel_heading_envs=1.0,
         heading_command=True,

--- a/source/extensions/omni.isaac.orbit_tasks/omni/isaac/orbit_tasks/manipulation/lift/lift_env_cfg.py
+++ b/source/extensions/omni.isaac.orbit_tasks/omni/isaac/orbit_tasks/manipulation/lift/lift_env_cfg.py
@@ -11,6 +11,7 @@ from dataclasses import MISSING
 import omni.isaac.orbit.sim as sim_utils
 from omni.isaac.orbit.assets import ArticulationCfg, AssetBaseCfg, RigidObjectCfg
 from omni.isaac.orbit.envs import RLTaskEnvCfg
+from omni.isaac.orbit.envs.mdp.commands.resampling import FixedFrequencyCfg
 from omni.isaac.orbit.managers import CurriculumTermCfg as CurrTerm
 from omni.isaac.orbit.managers import ObservationGroupCfg as ObsGroup
 from omni.isaac.orbit.managers import ObservationTermCfg as ObsTerm
@@ -78,7 +79,7 @@ class CommandsCfg:
     object_pose = mdp.UniformPoseCommandCfg(
         asset_name="robot",
         body_name=MISSING,  # will be set by agent env cfg
-        resampling_time_range=(5.0, 5.0),
+        resampling={"fixed_frequency": FixedFrequencyCfg(resampling_time_range=(5.0, 5.0))},
         debug_vis=True,
         ranges=mdp.UniformPoseCommandCfg.Ranges(
             pos_x=(0.4, 0.6), pos_y=(-0.25, 0.25), pos_z=(0.25, 0.5), roll=(0.0, 0.0), pitch=(0.0, 0.0), yaw=(0.0, 0.0)

--- a/source/extensions/omni.isaac.orbit_tasks/omni/isaac/orbit_tasks/manipulation/reach/reach_env_cfg.py
+++ b/source/extensions/omni.isaac.orbit_tasks/omni/isaac/orbit_tasks/manipulation/reach/reach_env_cfg.py
@@ -10,6 +10,7 @@ from dataclasses import MISSING
 import omni.isaac.orbit.sim as sim_utils
 from omni.isaac.orbit.assets import ArticulationCfg, AssetBaseCfg
 from omni.isaac.orbit.envs import RLTaskEnvCfg
+from omni.isaac.orbit.envs.mdp.commands.resampling import FixedFrequencyCfg
 from omni.isaac.orbit.managers import ActionTermCfg as ActionTerm
 from omni.isaac.orbit.managers import CurriculumTermCfg as CurrTerm
 from omni.isaac.orbit.managers import ObservationGroupCfg as ObsGroup
@@ -71,7 +72,7 @@ class CommandsCfg:
     ee_pose = mdp.UniformPoseCommandCfg(
         asset_name="robot",
         body_name=MISSING,
-        resampling_time_range=(4.0, 4.0),
+        resampling={"fixed_frequency": FixedFrequencyCfg(resampling_time_range=(4.0, 4.0))},
         debug_vis=True,
         ranges=mdp.UniformPoseCommandCfg.Ranges(
             pos_x=(0.35, 0.65),


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-orbit.github.io/orbit/source/refs/contributing.html
-->

This introduces the concept of a `ResamplingManager` and `ResamplingTerm`s. This generalizes command resampling beyond the currently implemented fixed time resampling.

Every `CommandTerm` now owns a `ResamplingManager` which it calls during the `compute()` call to determine whether commands should be resampled.
A `ResamplingManger` can contain multiple `RewardTerm`s to obtain diverse behavior.

All current example RL environment configs which used a command other than the `NullCommand` where changed to use the new `FixedFrequency` resampling term, which replicates the current behavior. The `NullCommand` now simply receives now `ResamplingTerm` and is therefore never resampled, as desired.

However, this is a breaking change for people who created their own RL configs outside of the Orbit main branch. Luckily, this is very easy to fix with a single line code change:

`resampling_time_range=(10.0, 10.0)`--> `resampling={"fixed_frequency": FixedFrequencyCfg(resampling_time_range=(10.0, 10.0))},`

I also added a new `RandomChance` resampling term as an example, which resamples environments with a fixed probability.

Fixes #223 

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update (probably)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./orbit.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run all the tests with `./orbit.sh --test` and they pass
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
