### PR TITLE
Make `create_empty.py` less verbose - easier for beginners

### DIFF
--- a/source/standalone/tutorials/00_sim/create_empty.py
+++ b/source/standalone/tutorials/00_sim/create_empty.py
@@ -19,13 +19,12 @@ import argparse
 
 from omni.isaac.orbit.app import AppLauncher
 
-# create argparser
+# Create argparser
 parser = argparse.ArgumentParser(description="Tutorial on creating an empty stage.")
-# append AppLauncher cli args
-AppLauncher.add_app_launcher_args(parser)
-# parse the arguments
+AppLauncher.add_app_launcher_args(parser)  # appends some our AppLauncher cli args
 args_cli = parser.parse_args()
-# launch omniverse app
+
+# Launch omniverse app
 app_launcher = AppLauncher(args_cli)
 simulation_app = app_launcher.app
 
@@ -35,27 +34,19 @@ from omni.isaac.orbit.sim import SimulationCfg, SimulationContext
 
 
 def main():
-    """Main function."""
-
     # Initialize the simulation context
     sim_cfg = SimulationCfg(dt=0.01, substeps=1)
     sim = SimulationContext(sim_cfg)
-    # Set main camera
-    sim.set_camera_view([2.5, 2.5, 2.5], [0.0, 0.0, 0.0])
 
-    # Play the simulator
-    sim.reset()
-    # Now we are ready!
+    sim.set_camera_view([2.5, 2.5, 2.5], [0.0, 0.0, 0.0])  # (optional)
+
+    sim.reset()  # plays the simulator
     print("[INFO]: Setup complete...")
 
-    # Simulate physics
     while simulation_app.is_running():
-        # perform step
-        sim.step()
+        sim.step()  # simulates physics
 
 
 if __name__ == "__main__":
-    # run the main function
     main()
-    # close sim app
     simulation_app.close()


### PR DESCRIPTION
# Description

For me personally (as a beginner), the current file is too verbose - all the comments stand in the way of clearly seeing only the operations which need to happen.

Plus, some comments just repeat the function names (like main) which doesn't really add info. Code here can be [self-documenting](https://en.wikipedia.org/wiki/Self-documenting_code).

The proposed result (without red/green diffs): [here](https://github.com/VladimirFokow/orbit/blob/1ce7f54da5e3006ce27c4b90e4f9bc50c82c8dd3/source/standalone/tutorials/00_sim/create_empty.py#L22-L52).


TODO (after the code has been approved): 

- update the line numbers which highlight the code in the docs

## Type of change

- This change requires a documentation update

## Checklist

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./orbit.sh --format`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run all the tests with `./orbit.sh --test` and they pass
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
