### PR TITLE
Fixes apply actions method in the `NonHolonomicAction` action term class

### DIFF
--- a/source/extensions/omni.isaac.orbit/config/extension.toml
+++ b/source/extensions/omni.isaac.orbit/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.15.1"
+version = "0.15.2"
 
 # Description
 title = "ORBIT framework for Robot Learning"

--- a/source/extensions/omni.isaac.orbit/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.orbit/docs/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+0.15.2 (2024-03-21)
+~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed the NonHolonomicActionCfg variable naming from joint_vel to _joint_vel_command to match the initalized variable in the init() function.
+
 0.15.1 (2024-03-19)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/extensions/omni.isaac.orbit/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.orbit/docs/CHANGELOG.rst
@@ -7,7 +7,7 @@ Changelog
 Fixed
 ^^^^^
 
-* Fixed the NonHolonomicActionCfg variable naming from joint_vel to _joint_vel_command to match the initalized variable in the init() function.
+* Fixed the NonHolonomicActionCfg variable naming from joint_vel to _joint_vel_command to match the initialized variable in the init() function.
 
 0.15.1 (2024-03-19)
 ~~~~~~~~~~~~~~~~~~~

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/actions/non_holonomic_actions.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/envs/mdp/actions/non_holonomic_actions.py
@@ -134,8 +134,8 @@ class NonHolonomicAction(ActionTerm):
         quat_w = self._asset.data.body_quat_w[:, self._body_idx]
         yaw_w = euler_xyz_from_quat(quat_w)[2]
         # compute joint velocities targets
-        self.joint_vel[:, 0] = torch.cos(yaw_w) * self.processed_actions[:, 0]  # x
-        self.joint_vel[:, 1] = torch.sin(yaw_w) * self.processed_actions[:, 0]  # y
-        self.joint_vel[:, 2] = self.processed_actions[:, 1]  # yaw
+        self._joint_vel_command[:, 0] = torch.cos(yaw_w) * self.processed_actions[:, 0]  # x
+        self._joint_vel_command[:, 1] = torch.sin(yaw_w) * self.processed_actions[:, 0]  # y
+        self._joint_vel_command[:, 2] = self.processed_actions[:, 1]  # yaw
         # set the joint velocity targets
-        self._asset.set_joint_velocity_target(self.joint_vel, joint_ids=self._joint_ids)
+        self._asset.set_joint_velocity_target(self._joint_vel_command, joint_ids=self._joint_ids)


### PR DESCRIPTION
# Description

in `NonHolonomicAction.apply_actions()` the velocity command was incorrectly named `self.joint_vel` instead of `self._joint_vel_command` as initialized in `NonHolonomicAction.__init__()`. This causes an error when trying to instantiate the action config. I have made the correction and tested that it works.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Please attach before and after screenshots of the change if applicable.

Before:
```
    def apply_actions(self):
        # obtain current heading
        quat_w = self._asset.data.body_quat_w[:, self._body_idx]
        yaw_w = euler_xyz_from_quat(quat_w)[2]
        # compute joint velocities targets
        self.joint_vel[:, 0] = torch.cos(yaw_w) * self.processed_actions[:, 0]  # x
        self.joint_vel[:, 1] = torch.sin(yaw_w) * self.processed_actions[:, 0]  # y
        self.joint_vel[:, 2] = self.processed_actions[:, 1]  # yaw
        # set the joint velocity targets
        self._asset.set_joint_velocity_target(self.joint_vel, joint_ids=self._joint_ids)
```

After:
```
    def apply_actions(self):
        # obtain current heading
        quat_w = self._asset.data.body_quat_w[:, self._body_idx]
        yaw_w = euler_xyz_from_quat(quat_w)[2]
        # compute joint velocities targets
        self._joint_vel_command[:, 0] = torch.cos(yaw_w) * self.processed_actions[:, 0]  # x
        self._joint_vel_command[:, 1] = torch.sin(yaw_w) * self.processed_actions[:, 0]  # y
        self._joint_vel_command[:, 2] = self.processed_actions[:, 1]  # yaw
        # set the joint velocity targets
        self._asset.set_joint_velocity_target(self._joint_vel_command, joint_ids=self._joint_ids)
```

## Checklist

- [X] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./orbit.sh --format`
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have run all the tests with `./orbit.sh --test` and they pass
- [X] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
