### PR TITLE
Fixes unused `keep_invalid` arg in `create_pointcloud_from_depth` method

### DIFF
--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sensors/camera/utils.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sensors/camera/utils.py
@@ -144,9 +144,11 @@ def create_pointcloud_from_depth(
     depth_cloud = math_utils.unproject_depth(depth, intrinsic_matrix)
     # convert 3D points to world frame
     depth_cloud = math_utils.transform_points(depth_cloud, position, orientation)
-    # keep only valid entries
-    pts_idx_to_keep = torch.all(torch.logical_and(~torch.isnan(depth_cloud), ~torch.isinf(depth_cloud)), dim=1)
-    depth_cloud = depth_cloud[pts_idx_to_keep, ...]
+    
+    if not keep_invalid:
+        # keep only valid entries
+        pts_idx_to_keep = torch.all(torch.logical_and(~torch.isnan(depth_cloud), ~torch.isinf(depth_cloud)), dim=1)
+        depth_cloud = depth_cloud[pts_idx_to_keep, ...]
 
     # return everything according to input type
     if is_numpy:


### PR DESCRIPTION
# Description

This is a simple fix of unused parameter in omni/isaac/orbit./sensors/camera/utils.py 

The parameter `keep_invalid` was not used and, by default, only returns valid points, which causes an issue when trying to do an RGB-D image to point cloud cconversion. This leads to an array size mismatch if depth has inf or nan. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./orbit.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run all the tests with `./orbit.sh --test` and they pass
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there