### PR TITLE
[Bug #339] fixing version not found launch issue with latest orbit commit

### DIFF
--- a/source/apps/orbit.python.headless.kit
+++ b/source/apps/orbit.python.headless.kit
@@ -16,7 +16,7 @@ keywords = ["experience", "app", "orbit", "python", "headless"]
 [settings]
 # Note: This path was adapted to be respective to the kit-exe file location
 app.versionFile = "${exe-path}/../VERSION"
-app.folder = "${exe-path}/../"
+app.folder = "${exe-path}/"
 app.name = "Isaac-Sim"
 app.version = "2023.1.1"
 

--- a/source/apps/orbit.python.headless.multicam.kit
+++ b/source/apps/orbit.python.headless.multicam.kit
@@ -49,7 +49,7 @@ keywords = ["experience", "app", "orbit", "python", "camera", "minimal"]
 ################################
 # Note: This path was adapted to be respective to the kit-exe file location
 app.versionFile = "${exe-path}/../VERSION"
-app.folder = "${exe-path}/../"
+app.folder = "${exe-path}/"
 app.name = "Isaac-Sim"
 app.version = "2023.1.1"
 

--- a/source/apps/orbit.python.kit
+++ b/source/apps/orbit.python.kit
@@ -16,7 +16,7 @@ keywords = ["experience", "app", "orbit", "python"]
 [settings]
 # Note: This path was adapted to be respective to the kit-exe file location
 app.versionFile = "${exe-path}/../VERSION"
-app.folder = "${exe-path}/../"
+app.folder = "${exe-path}/"
 app.name = "Isaac-Sim"
 app.version = "2023.1.1"
 


### PR DESCRIPTION
The AppLauncher has a bug where it fails to fact the app.folder is pointing a directory higher than it should be. This leads to a fild not found in _get_version call in omni.isaac.version

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://isaac-orbit.github.io/orbit/source/refs/contributing.html
-->

Updated app.folder to point to `"${exe-path}/"` instead of `"${exe-path}/../"` in the following files:

- orbit/source/apps/orbit.python.headless.kit
- orbit/source/apps/orbit.python.headless.multicam.kit
- orbit/source/apps/orbit.python.kit

Fixes # (339)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

- Wrong Path  Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./orbit.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run all the tests with `./orbit.sh --test` and they pass
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

