### PR TITLE
Adds `fix_root_link` attribute to ArticulationRootPropertiesCfg 

### DIFF
--- a/docs/source/how-to/index.rst
+++ b/docs/source/how-to/index.rst
@@ -15,6 +15,7 @@ use Orbit. If you are new to Orbit, we recommend you start with the tutorials.
 
     import_new_asset
     write_articulation_cfg
+    make_static_prim
     save_camera_output
     draw_markers
     wrap_rl_env

--- a/docs/source/how-to/make_static_prim.rst
+++ b/docs/source/how-to/make_static_prim.rst
@@ -32,7 +32,7 @@ For instance, to spawn a cone static in the simulation world, the following code
         visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.0, 1.0, 0.0)),
     )
     cone_spawn_cfg.func(
-        "/World/ConeKinematicRigid", cone_spawn_cfg, translation=(0.0, 0.0, 2.0), orientation=(0.5, 0.0, 0.5, 0.0)
+        "/World/Cone", cone_spawn_cfg, translation=(0.0, 0.0, 2.0), orientation=(0.5, 0.0, 0.5, 0.0)
     )
 
 

--- a/docs/source/how-to/make_static_prim.rst
+++ b/docs/source/how-to/make_static_prim.rst
@@ -39,9 +39,14 @@ For instance, to spawn a cone static in the simulation world, the following code
 Articulation
 ------------
 
-Making an articulation static requires adding a fixed joint to the root link of the articulation.
+Making an articulation static requires having a fixed joint to the root rigid body link of the articulation.
 This can be achieved by setting the parameter :attr:`sim.schemas.ArticulationRootPropertiesCfg.fix_root_link`
-as True.
+as True. Based on the value of this parameter, the following cases are possible:
+
+* If set to :obj:`None`, the root link is not modified.
+* If the articulation already has a fixed root link, this flag will enable or disable the fixed joint.
+* If the articulation does not have a fixed root link, this flag will create a fixed joint between the world
+  frame and the root link. The joint is created with the name "FixedJoint".
 
 For instance, to spawn an ANYmal robot and make it static in the simulation world, the following code can be used:
 
@@ -70,5 +75,28 @@ For instance, to spawn an ANYmal robot and make it static in the simulation worl
         ),
     )
     anymal_spawn_cfg.func(
-        "/World/ANYmalFixed", anymal_spawn_cfg, translation=(0.0, 0.0, 0.8), orientation=(1.0, 0.0, 0.0, 0.0)
+        "/World/ANYmal", anymal_spawn_cfg, translation=(0.0, 0.0, 0.8), orientation=(1.0, 0.0, 0.0, 0.0)
     )
+
+
+This will create a fixed joint between the world frame and the root link of the ANYmal robot
+at the prim path ``"/World/ANYmal/base/FixedJoint"`` since the root link is at the path ``"/World/ANYmal/base"``.
+
+
+Further notes
+-------------
+
+For floating base articulations, the root prim usually has both the rigid body and the articulation
+root properties. However, directly connecting this prim to the world frame will cause the simulation
+to consider the fixed joint as a part of the maximal coordinate tree. This is different from PhysX
+considering the articulation as a fixed-base system.
+
+Internally, when the parameter :attr:`sim.schemas.ArticulationRootPropertiesCfg.fix_root_link` is set to True
+and the articulation is detected as a floating-base system, the fixed joint is created between the world frame
+the root rigid body link of the articulation. However, to make the PhysX parser consider the articulation as a
+fixed-base system, the articulation root properties are removed from the root rigid body prim and applied to
+its parent prim instead.
+
+Note:
+    In future release of Isaac Sim, an explicit flag will be added to the articulation root schema from PhysX
+    to toggle between fixed-base and floating-base systems. This will resolve the need of the above workaround.

--- a/docs/source/how-to/make_static_prim.rst
+++ b/docs/source/how-to/make_static_prim.rst
@@ -97,6 +97,7 @@ the root rigid body link of the articulation. However, to make the PhysX parser 
 fixed-base system, the articulation root properties are removed from the root rigid body prim and applied to
 its parent prim instead.
 
-Note:
+.. note::
+
     In future release of Isaac Sim, an explicit flag will be added to the articulation root schema from PhysX
     to toggle between fixed-base and floating-base systems. This will resolve the need of the above workaround.

--- a/docs/source/how-to/make_static_prim.rst
+++ b/docs/source/how-to/make_static_prim.rst
@@ -46,7 +46,7 @@ as True. Based on the value of this parameter, the following cases are possible:
 * If set to :obj:`None`, the root link is not modified.
 * If the articulation already has a fixed root link, this flag will enable or disable the fixed joint.
 * If the articulation does not have a fixed root link, this flag will create a fixed joint between the world
-  frame and the root link. The joint is created with the name "FixedJoint".
+  frame and the root link. The joint is created with the name "FixedJoint" under the root link.
 
 For instance, to spawn an ANYmal robot and make it static in the simulation world, the following code can be used:
 

--- a/docs/source/how-to/make_static_prim.rst
+++ b/docs/source/how-to/make_static_prim.rst
@@ -1,0 +1,74 @@
+Making a physics prim static in the simulation
+==============================================
+
+.. currentmodule:: omni.isaac.orbit
+
+When a USD prim has physics schemas applied on it, it is affected by physics simulation.
+This means that the prim can move, rotate, and collide with other prims in the simulation world.
+However, there are cases where it is desirable to make certain prims static in the simulation world,
+i.e. the prim should still participate in collisions but its position and orientation should not change.
+
+The following sections describe how to spawn a prim with physics schemas and make it static in the simulation world.
+
+Rigid object
+------------
+
+Rigid objects (i.e. object only has a single body) can be made static by setting the parameter
+:attr:`sim.schemas.RigidBodyPropertiesCfg.kinematic_enabled` as True. This will make the object
+kinematic and it will not be affected by physics.
+
+For instance, to spawn a cone static in the simulation world, the following code can be used:
+
+.. code-block:: python
+
+    import omni.isaac.orbit.sim as sim_utils
+
+    cone_spawn_cfg = sim_utils.ConeCfg(
+        radius=0.15,
+        height=0.5,
+        rigid_props=sim_utils.RigidBodyPropertiesCfg(kinematic_enabled=True),
+        mass_props=sim_utils.MassPropertiesCfg(mass=1.0),
+        collision_props=sim_utils.CollisionPropertiesCfg(),
+        visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.0, 1.0, 0.0)),
+    )
+    cone_spawn_cfg.func(
+        "/World/ConeKinematicRigid", cone_spawn_cfg, translation=(0.0, 0.0, 2.0), orientation=(0.5, 0.0, 0.5, 0.0)
+    )
+
+
+Articulation
+------------
+
+Making an articulation static requires adding a fixed joint to the root link of the articulation.
+This can be achieved by setting the parameter :attr:`sim.schemas.ArticulationRootPropertiesCfg.fix_root_link`
+as True.
+
+For instance, to spawn an ANYmal robot and make it static in the simulation world, the following code can be used:
+
+.. code-block:: python
+
+    import omni.isaac.orbit.sim as sim_utils
+    from omni.isaac.orbit.utils.assets import ISAAC_ORBIT_NUCLEUS_DIR
+
+    anymal_spawn_cfg = sim_utils.UsdFileCfg(
+        usd_path=f"{ISAAC_ORBIT_NUCLEUS_DIR}/Robots/ANYbotics/ANYmal-C/anymal_c.usd",
+        activate_contact_sensors=True,
+        rigid_props=sim_utils.RigidBodyPropertiesCfg(
+            disable_gravity=False,
+            retain_accelerations=False,
+            linear_damping=0.0,
+            angular_damping=0.0,
+            max_linear_velocity=1000.0,
+            max_angular_velocity=1000.0,
+            max_depenetration_velocity=1.0,
+        ),
+        articulation_props=sim_utils.ArticulationRootPropertiesCfg(
+            enabled_self_collisions=True,
+            solver_position_iteration_count=4,
+            solver_velocity_iteration_count=0,
+            fix_root_link=True,
+        ),
+    )
+    anymal_spawn_cfg.func(
+        "/World/ANYmalFixed", anymal_spawn_cfg, translation=(0.0, 0.0, 0.8), orientation=(1.0, 0.0, 0.0, 0.0)
+    )

--- a/source/extensions/omni.isaac.orbit/config/extension.toml
+++ b/source/extensions/omni.isaac.orbit/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.16.0"
+version = "0.16.1"
 
 # Description
 title = "ORBIT framework for Robot Learning"

--- a/source/extensions/omni.isaac.orbit/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.orbit/docs/CHANGELOG.rst
@@ -1,6 +1,16 @@
 Changelog
 ---------
 
+0.16.1 (2024-04-20)
+~~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Added attribute :attr:`omni.isaac.orbit.sim.ArticulationRootPropertiesCfg.fix_root_link` to fix the root link
+  of an articulation to the world frame.
+
+
 0.16.0 (2024-04-16)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/schemas/schemas.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/schemas/schemas.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import carb
 import omni.isaac.core.utils.stage as stage_utils
-from pxr import PhysxSchema, Usd, UsdPhysics
+from pxr import PhysxSchema, Sdf, Usd, UsdPhysics
 
 from ..utils import apply_nested, find_global_fixed_joint_prim, safe_set_attribute_on_usd_schema
 from . import schemas_cfg
@@ -114,9 +114,8 @@ def modify_articulation_root_properties(
             # create a fixed joint between the root link and the world frame
             joint_prim = UsdPhysics.FixedJoint.Define(stage, f"{prim_path}/rootJoint")
             joint_prim.GetJointEnabledAttr().Set(fix_root_link)
-            joint_prim.GetBody1Rel().SetTargets([prim_path])
-            # apply physx joint api
-            PhysxSchema.PhysxJointAPI.Apply(joint_prim.GetPrim())
+            joint_prim.CreateBody0Rel().SetTargets([])
+            joint_prim.CreateBody1Rel().SetTargets([Sdf.Path(prim_path)])
 
     # set into physx api
     for attr_name, value in cfg.items():

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/schemas/schemas.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/schemas/schemas.py
@@ -8,7 +8,8 @@ from __future__ import annotations
 
 import carb
 import omni.isaac.core.utils.stage as stage_utils
-from pxr import PhysxSchema, Sdf, Usd, UsdPhysics
+import omni.kit.commands
+from pxr import PhysxSchema, Usd, UsdPhysics
 
 from ..utils import apply_nested, find_global_fixed_joint_prim, safe_set_attribute_on_usd_schema
 from . import schemas_cfg
@@ -112,10 +113,13 @@ def modify_articulation_root_properties(
         elif fix_root_link:
             carb.log_info(f"Creating a fixed joint for the articulation root prim: '{prim_path}'.")
             # create a fixed joint between the root link and the world frame
-            joint_prim = UsdPhysics.FixedJoint.Define(stage, f"{prim_path}/rootJoint")
-            joint_prim.GetJointEnabledAttr().Set(fix_root_link)
-            joint_prim.CreateBody0Rel().SetTargets([])
-            joint_prim.CreateBody1Rel().SetTargets([Sdf.Path(prim_path)])
+            omni.kit.commands.execute(
+                "CreateJointCommand", stage=stage, joint_type="Fixed", from_prim=None, to_prim=articulation_prim
+            )
+            # joint_prim = UsdPhysics.FixedJoint.Define(stage, f"{prim_path}/rootJoint")
+            # joint_prim.GetJointEnabledAttr().Set(fix_root_link)
+            # joint_prim.CreateBody0Rel().SetTargets([])
+            # joint_prim.CreateBody1Rel().SetTargets([prim_path])
 
     # set into physx api
     for attr_name, value in cfg.items():

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/schemas/schemas.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/schemas/schemas.py
@@ -110,11 +110,12 @@ def modify_articulation_root_properties(
         if existing_fixed_joint_prim is not None:
             existing_fixed_joint_prim.GetJointEnabledAttr().Set(fix_root_link)
         elif fix_root_link:
+            carb.log_info(f"Creating a fixed joint for the articulation root prim: '{prim_path}'.")
             # create a fixed joint between the root link and the world frame
             joint_prim = UsdPhysics.FixedJoint.Define(stage, f"{prim_path}/rootJoint")
             joint_prim.GetJointEnabledAttr().Set(fix_root_link)
             joint_prim.GetBody1Rel().SetTargets([prim_path])
-            # apply phyx joint api
+            # apply physx joint api
             PhysxSchema.PhysxJointAPI.Apply(joint_prim.GetPrim())
 
     # set into physx api

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/schemas/schemas.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/schemas/schemas.py
@@ -135,9 +135,9 @@ def modify_articulation_root_properties(
             # there is no obvious way to get first rigid body link in an articulation tree
             if not articulation_prim.HasAPI(UsdPhysics.RigidBodyAPI):
                 raise NotImplementedError(
-                    "The root prim does not have the RigidBodyAPI applied. To create a fixed joint,"
-                    " we need to determine the first rigid body link in the articulation tree."
-                    " However, this is not implemented yet."
+                    f"The articulation prim '{prim_path}' does not have the RigidBodyAPI applied."
+                    " To create a fixed joint, we need to determine the first rigid body link in"
+                    " the articulation tree. However, this is not implemented yet."
                 )
 
             # create a fixed joint between the root link and the world frame

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/schemas/schemas_cfg.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/schemas/schemas_cfg.py
@@ -37,7 +37,7 @@ class ArticulationRootPropertiesCfg:
     * If set to None, the root link is not modified.
     * If the articulation already has a fixed root link, this flag will enable or disable the fixed joint.
     * If the articulation does not have a fixed root link, this flag will create a fixed joint between the world
-      frame and the root link. The joint is created with the name "rootJoint".
+      frame and the root link. The joint is created with the name "FixedJoint".
 
     .. note::
         This is a non-USD schema property. It is handled by the :meth:`modify_articulation_root_properties` function.

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/schemas/schemas_cfg.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/schemas/schemas_cfg.py
@@ -31,6 +31,18 @@ class ArticulationRootPropertiesCfg:
     """Mass-normalized kinetic energy threshold below which an actor may go to sleep."""
     stabilization_threshold: float | None = None
     """The mass-normalized kinetic energy threshold below which an articulation may participate in stabilization."""
+    fix_root_link: bool | None = None
+    """Whether to fix the root link of the articulation.
+
+    * If set to None, the root link is not modified.
+    * If the articulation already has a fixed root link, this flag will enable or disable the fixed joint.
+    * If the articulation does not have a fixed root link, this flag will create a fixed joint between the world
+      frame and the root link. The joint is created with the name "rootJoint".
+
+    .. note::
+        This is a non-USD schema property. It is handled by the :meth:`modify_articulation_root_properties` function.
+
+    """
 
 
 @configclass

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/schemas/schemas_cfg.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/schemas/schemas_cfg.py
@@ -37,7 +37,7 @@ class ArticulationRootPropertiesCfg:
     * If set to None, the root link is not modified.
     * If the articulation already has a fixed root link, this flag will enable or disable the fixed joint.
     * If the articulation does not have a fixed root link, this flag will create a fixed joint between the world
-      frame and the root link. The joint is created with the name "FixedJoint".
+      frame and the root link. The joint is created with the name "FixedJoint" under the articulation prim.
 
     .. note::
         This is a non-USD schema property. It is handled by the :meth:`modify_articulation_root_properties` function.

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/spawners/from_files/from_files.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/spawners/from_files/from_files.py
@@ -11,7 +11,6 @@ import carb
 import omni.isaac.core.utils.prims as prim_utils
 import omni.isaac.core.utils.stage as stage_utils
 import omni.kit.commands
-from omni.isaac.core.prims.xform_prim import XFormPrim
 from pxr import Gf, Sdf, Usd
 
 from omni.isaac.orbit.sim import converters, schemas
@@ -224,7 +223,13 @@ def _spawn_from_usd_file(
     # spawn asset if it doesn't exist.
     if not prim_utils.is_prim_path_valid(prim_path):
         # add prim as reference to stage
-        stage_utils.add_reference_to_stage(usd_path, prim_path)
+        prim_utils.create_prim(
+            prim_path,
+            usd_path=usd_path,
+            translation=translation,
+            orientation=orientation,
+            scale=cfg.scale,
+        )
     else:
         carb.log_warn(f"A prim already exists at prim path: '{prim_path}'.")
 
@@ -260,9 +265,6 @@ def _spawn_from_usd_file(
         cfg.visual_material.func(material_path, cfg.visual_material)
         # apply material
         bind_visual_material(prim_path, material_path)
-
-    # apply translation and orientation
-    XFormPrim(prim_path=prim_path, translation=translation, orientation=orientation, scale=cfg.scale)
 
     # return the prim
     return prim_utils.get_prim_at_path(prim_path)

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/spawners/from_files/from_files.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/spawners/from_files/from_files.py
@@ -11,6 +11,7 @@ import carb
 import omni.isaac.core.utils.prims as prim_utils
 import omni.isaac.core.utils.stage as stage_utils
 import omni.kit.commands
+from omni.isaac.core.prims.xform_prim import XFormPrim
 from pxr import Gf, Sdf, Usd
 
 from omni.isaac.orbit.sim import converters, schemas
@@ -223,13 +224,7 @@ def _spawn_from_usd_file(
     # spawn asset if it doesn't exist.
     if not prim_utils.is_prim_path_valid(prim_path):
         # add prim as reference to stage
-        prim_utils.create_prim(
-            prim_path,
-            usd_path=usd_path,
-            translation=translation,
-            orientation=orientation,
-            scale=cfg.scale,
-        )
+        stage_utils.add_reference_to_stage(usd_path, prim_path)
     else:
         carb.log_warn(f"A prim already exists at prim path: '{prim_path}'.")
 
@@ -265,6 +260,9 @@ def _spawn_from_usd_file(
         cfg.visual_material.func(material_path, cfg.visual_material)
         # apply material
         bind_visual_material(prim_path, material_path)
+
+    # apply translation and orientation
+    XFormPrim(prim_path=prim_path, translation=translation, orientation=orientation, scale=cfg.scale)
 
     # return the prim
     return prim_utils.get_prim_at_path(prim_path)

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/spawners/shapes/shapes.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/spawners/shapes/shapes.py
@@ -221,7 +221,7 @@ Helper functions.
 
 def _spawn_geom_from_prim_type(
     prim_path: str,
-    cfg: shapes_cfg.GeometryCfg,
+    cfg: shapes_cfg.ShapeCfg,
     prim_type: str,
     attributes: dict,
     translation: tuple[float, float, float] | None = None,

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/spawners/spawner_cfg.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/spawners/spawner_cfg.py
@@ -83,8 +83,14 @@ class RigidObjectSpawnerCfg(SpawnerCfg):
 
     mass_props: schemas.MassPropertiesCfg | None = None
     """Mass properties."""
+
     rigid_props: schemas.RigidBodyPropertiesCfg | None = None
-    """Rigid body properties."""
+    """Rigid body properties.
+
+    For making a rigid object static, set the :attr:`schemas.RigidBodyPropertiesCfg.kinematic_enabled`
+    as True. This will make the object static and will not be affected by gravity or other forces.
+    """
+
     collision_props: schemas.CollisionPropertiesCfg | None = None
     """Properties to apply to all collision meshes."""
 

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/utils.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/utils.py
@@ -718,3 +718,55 @@ def find_matching_prim_paths(prim_path_regex: str, stage: Usd.Stage | None = Non
     for prim in output_prims:
         output_prim_paths.append(prim.GetPath().pathString)
     return output_prim_paths
+
+
+def find_global_fixed_joint_prim(
+    prim_path: str | Sdf.Path, stage: Usd.Stage | None = None
+) -> UsdPhysics.FixedJoint | None:
+    """Find the fixed joint prim under the specified prim path that connects the target to the simulation world.
+
+    A joint is a connection between two bodies. A fixed joint is a joint that does not allow relative motion
+    between the two bodies. When a fixed joint has only one target body, it is considered to attach the body
+    to the simulation world.
+
+    This function finds the fixed joint prim that has only one target under the specified prim path. If no such
+    fixed joint prim exists, it returns None.
+
+    Args:
+        prim_path: The prim path to search for the fixed joint prim.
+        stage: The stage where the prim exists. Defaults to None, in which case the current stage is used.
+
+    Returns:
+        The fixed joint prim that has only one target. If no such fixed joint prim exists, it returns None.
+
+    Raises:
+        ValueError: If the prim path is not global (i.e: does not start with '/').
+        ValueError: If the prim path does not exist on the stage.
+    """
+    # check prim path is global
+    if not prim_path.startswith("/"):
+        raise ValueError(f"Prim path '{prim_path}' is not global. It must start with '/'.")
+    # get current stage
+    if stage is None:
+        stage = stage_utils.get_current_stage()
+
+    # check if prim exists
+    prim = stage.GetPrimAtPath(prim_path)
+    if not prim.IsValid():
+        raise ValueError(f"Prim at path '{prim_path}' is not valid.")
+
+    fixed_joint_prim = None
+    # we check all joints under the root prim and classify the asset as fixed base if there exists
+    # a fixed joint that has only one target (i.e. the root link).
+    for prim in Usd.PrimRange(prim):
+        joint_prim = UsdPhysics.FixedJoint(prim)
+        if joint_prim and joint_prim.GetJointEnabledAttr().Get():
+            # check body 0 and body 1 exist
+            body_0_exist = joint_prim.GetBody0Rel().GetTargets() != []
+            body_1_exist = joint_prim.GetBody1Rel().GetTargets() != []
+            # if either body 0 or body 1 does not exist, we have a fixed joint that connects to the world
+            if not (body_0_exist and body_1_exist):
+                fixed_joint_prim = joint_prim
+                break
+
+    return fixed_joint_prim

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/utils.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/utils.py
@@ -759,7 +759,9 @@ def find_global_fixed_joint_prim(
     # we check all joints under the root prim and classify the asset as fixed base if there exists
     # a fixed joint that has only one target (i.e. the root link).
     for prim in Usd.PrimRange(prim):
-        joint_prim = UsdPhysics.FixedJoint(prim)
+        # note: ideally checking if it is FixedJoint would have been enough, but some assets use "Joint" as the
+        # schema name which makes it difficult to distinguish between the two.
+        joint_prim = UsdPhysics.Joint(prim)
         if joint_prim and joint_prim.GetJointEnabledAttr().Get():
             # check body 0 and body 1 exist
             body_0_exist = joint_prim.GetBody0Rel().GetTargets() != []

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/utils.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/utils.py
@@ -721,8 +721,8 @@ def find_matching_prim_paths(prim_path_regex: str, stage: Usd.Stage | None = Non
 
 
 def find_global_fixed_joint_prim(
-    prim_path: str | Sdf.Path, stage: Usd.Stage | None = None
-) -> UsdPhysics.FixedJoint | None:
+    prim_path: str | Sdf.Path, check_enabled_only: bool = False, stage: Usd.Stage | None = None
+) -> UsdPhysics.Joint | None:
     """Find the fixed joint prim under the specified prim path that connects the target to the simulation world.
 
     A joint is a connection between two bodies. A fixed joint is a joint that does not allow relative motion
@@ -734,6 +734,8 @@ def find_global_fixed_joint_prim(
 
     Args:
         prim_path: The prim path to search for the fixed joint prim.
+        check_enabled_only: Whether to consider only enabled fixed joints. Defaults to False.
+            If False, then all joints (enabled or disabled) are considered.
         stage: The stage where the prim exists. Defaults to None, in which case the current stage is used.
 
     Returns:
@@ -762,7 +764,10 @@ def find_global_fixed_joint_prim(
         # note: ideally checking if it is FixedJoint would have been enough, but some assets use "Joint" as the
         # schema name which makes it difficult to distinguish between the two.
         joint_prim = UsdPhysics.Joint(prim)
-        if joint_prim and joint_prim.GetJointEnabledAttr().Get():
+        if joint_prim:
+            # if check_enabled_only is True, we only consider enabled joints
+            if check_enabled_only and not joint_prim.GetJointEnabledAttr().Get():
+                continue
             # check body 0 and body 1 exist
             body_0_exist = joint_prim.GetBody0Rel().GetTargets() != []
             body_1_exist = joint_prim.GetBody1Rel().GetTargets() != []

--- a/source/extensions/omni.isaac.orbit/test/assets/check_fixed_base_assets.py
+++ b/source/extensions/omni.isaac.orbit/test/assets/check_fixed_base_assets.py
@@ -1,0 +1,165 @@
+# Copyright (c) 2022-2024, The ORBIT Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""
+This script demonstrates fixed-base API for different robots.
+
+.. code-block:: bash
+
+    # Usage
+    ./orbit.sh -p source/extensions/omni.isaac.orbit/test/assets/check_fixed_base_assets.py
+
+"""
+
+"""Launch Isaac Sim Simulator first."""
+
+import argparse
+
+from omni.isaac.orbit.app import AppLauncher
+
+# add argparse arguments
+parser = argparse.ArgumentParser(description="This script checks the fixed-base API for different robots.")
+# append AppLauncher cli args
+AppLauncher.add_app_launcher_args(parser)
+# parse the arguments
+args_cli = parser.parse_args()
+
+# launch omniverse app
+app_launcher = AppLauncher(args_cli)
+simulation_app = app_launcher.app
+
+"""Rest everything follows."""
+
+import numpy as np
+import torch
+
+import omni.isaac.core.utils.prims as prim_utils
+
+import omni.isaac.orbit.sim as sim_utils
+from omni.isaac.orbit.assets import Articulation
+
+##
+# Pre-defined configs
+##
+from omni.isaac.orbit_assets import ANYMAL_C_CFG, FRANKA_PANDA_CFG  # isort:skip
+
+
+def define_origins(num_origins: int, spacing: float) -> list[list[float]]:
+    """Defines the origins of the the scene."""
+    # create tensor based on number of environments
+    env_origins = torch.zeros(num_origins, 3)
+    # create a grid of origins
+    num_cols = np.floor(np.sqrt(num_origins))
+    num_rows = np.ceil(num_origins / num_cols)
+    xx, yy = torch.meshgrid(torch.arange(num_rows), torch.arange(num_cols), indexing="xy")
+    env_origins[:, 0] = spacing * xx.flatten()[:num_origins] - spacing * (num_rows - 1) / 2
+    env_origins[:, 1] = spacing * yy.flatten()[:num_origins] - spacing * (num_cols - 1) / 2
+    env_origins[:, 2] = 0.0
+    # return the origins
+    return env_origins.tolist()
+
+
+def design_scene() -> tuple[dict, list[list[float]]]:
+    """Designs the scene."""
+    # Ground-plane
+    cfg = sim_utils.GroundPlaneCfg()
+    cfg.func("/World/defaultGroundPlane", cfg)
+    # Lights
+    cfg = sim_utils.DomeLightCfg(intensity=2000.0, color=(0.75, 0.75, 0.75))
+    cfg.func("/World/Light", cfg)
+
+    # Create separate groups called "Origin1", "Origin2", "Origin3"
+    # Each group will have a mount and a robot on top of it
+    origins = define_origins(num_origins=4, spacing=2.0)
+
+    # Origin 1 with Anymal B
+    prim_utils.create_prim("/World/Origin1", "Xform", translation=origins[0])
+    # -- Robot
+    franka = Articulation(FRANKA_PANDA_CFG.replace(prim_path="/World/Origin1/Robot"))
+
+    # Origin 2 with Anymal C
+    prim_utils.create_prim("/World/Origin2", "Xform", translation=origins[1])
+    # -- Robot
+    robot_cfg = ANYMAL_C_CFG.replace(prim_path="/World/Origin2/Robot")
+    robot_cfg.spawn.articulation_props.fix_root_link = True
+    anymal_c = Articulation(robot_cfg)
+
+    # return the scene information
+    scene_entities = {
+        "franka": franka,
+        "anymal_c": anymal_c,
+    }
+    return scene_entities, origins
+
+
+def run_simulator(sim: sim_utils.SimulationContext, entities: dict[str, Articulation], origins: torch.Tensor):
+    """Runs the simulation loop."""
+    # Define simulation stepping
+    sim_dt = sim.get_physics_dt()
+    sim_time = 0.0
+    count = 0
+    # Simulate physics
+    while simulation_app.is_running():
+        # reset
+        if count % 200 == 0:
+            # reset counters
+            sim_time = 0.0
+            count = 0
+            # reset robots
+            for index, robot in enumerate(entities.values()):
+                # root state
+                root_state = robot.data.default_root_state.clone()
+                root_state[:, :3] += origins[index]
+                root_state[:, :2] += torch.randn_like(root_state[:, :2]) * 0.25
+                robot.write_root_state_to_sim(root_state)
+                # joint state
+                joint_pos, joint_vel = robot.data.default_joint_pos.clone(), robot.data.default_joint_vel.clone()
+                robot.write_joint_state_to_sim(joint_pos, joint_vel)
+                # reset the internal state
+                robot.reset()
+            print("[INFO]: Resetting robots state...")
+        # apply default actions to the quadrupedal robots
+        for name, robot in entities.items():
+            if count % 200 == 0:
+                print("name: fixed_base: ", name, robot.is_fixed_base)
+            # generate random joint positions
+            joint_pos_target = robot.data.default_joint_pos + torch.randn_like(robot.data.joint_pos) * 0.1
+            # apply action to the robot
+            robot.set_joint_position_target(joint_pos_target)
+            # write data to sim
+            robot.write_data_to_sim()
+        # perform step
+        sim.step()
+        # update sim-time
+        sim_time += sim_dt
+        count += 1
+        # update buffers
+        for robot in entities.values():
+            robot.update(sim_dt)
+
+
+def main():
+    """Main function."""
+
+    # Initialize the simulation context
+    sim = sim_utils.SimulationContext(sim_utils.SimulationCfg(dt=0.01, substeps=1))
+    # Set main camera
+    sim.set_camera_view(eye=[2.5, 2.5, 2.5], target=[0.0, 0.0, 0.0])
+    # design scene
+    scene_entities, scene_origins = design_scene()
+    scene_origins = torch.tensor(scene_origins, device=sim.device)
+    # Play the simulator
+    sim.reset()
+    # Now we are ready!
+    print("[INFO]: Setup complete...")
+    # Run the simulator
+    run_simulator(sim, scene_entities, scene_origins)
+
+
+if __name__ == "__main__":
+    # run the main function
+    main()
+    # close sim app
+    simulation_app.close()

--- a/source/extensions/omni.isaac.orbit/test/assets/test_articulation.py
+++ b/source/extensions/omni.isaac.orbit/test/assets/test_articulation.py
@@ -181,6 +181,9 @@ class TestArticulation(unittest.TestCase):
             self.sim.step()
             # update robot
             robot.update(self.dt)
+            # check that the root is at the correct state
+            default_root_state = robot.data.default_root_state.clone()
+            torch.testing.assert_close(robot.data.root_state_w, default_root_state)
 
     def test_initialization_fixed_base_single_joint(self):
         """Test initialization for fixed base articulation with a single joint."""
@@ -258,6 +261,89 @@ class TestArticulation(unittest.TestCase):
         self.assertEqual(robot.root_physx_view.max_dofs, robot.root_physx_view.shared_metatype.dof_count)
         # -- link related
         self.assertEqual(robot.root_physx_view.max_links, robot.root_physx_view.shared_metatype.link_count)
+
+        # Simulate physics
+        for _ in range(10):
+            # perform rendering
+            self.sim.step()
+            # update robot
+            robot.update(self.dt)
+
+    def test_initialization_floating_base_made_fixed_base(self):
+        """Test initialization for a floating-base articulation made fixed-base using schema properties."""
+        # Create articulation
+        robot_cfg: ArticulationCfg = ANYMAL_C_CFG.replace(prim_path="/World/Robot")
+        robot_cfg.spawn.articulation_props.fix_root_link = True
+        robot = Articulation(cfg=robot_cfg)
+
+        # Check that boundedness of articulation is correct
+        self.assertEqual(ctypes.c_long.from_address(id(robot)).value, 1)
+
+        # Play sim
+        self.sim.reset()
+        # Check if robot is initialized
+        self.assertTrue(robot._is_initialized)
+        # Check that floating base
+        self.assertTrue(robot.is_fixed_base)
+        # Check buffers that exists and have correct shapes
+        self.assertTrue(robot.data.root_pos_w.shape == (1, 3))
+        self.assertTrue(robot.data.root_quat_w.shape == (1, 4))
+        self.assertTrue(robot.data.joint_pos.shape == (1, 12))
+
+        # Check some internal physx data for debugging
+        # -- joint related
+        self.assertEqual(robot.root_physx_view.max_dofs, robot.root_physx_view.shared_metatype.dof_count)
+        # -- link related
+        self.assertEqual(robot.root_physx_view.max_links, robot.root_physx_view.shared_metatype.link_count)
+        # -- link names (check within articulation ordering is correct)
+        prim_path_body_names = [path.split("/")[-1] for path in robot.root_physx_view.link_paths[0]]
+        self.assertListEqual(prim_path_body_names, robot.body_names)
+
+        # Check that the body_physx_view is deprecated
+        with self.assertWarns(DeprecationWarning):
+            robot.body_physx_view
+
+        # Root state should be at the default state
+        robot.write_root_state_to_sim(robot.data.default_root_state.clone())
+        # Simulate physics
+        for _ in range(10):
+            # perform rendering
+            self.sim.step()
+            # update robot
+            robot.update(self.dt)
+            # check that the root is at the correct state
+            default_root_state = robot.data.default_root_state.clone()
+            torch.testing.assert_close(robot.data.root_state_w, default_root_state)
+
+    def test_initialization_fixed_base_made_floating_base(self):
+        """Test initialization for fixed base made floating-base using schema properties."""
+        # Create articulation
+        robot_cfg = FRANKA_PANDA_CFG.replace(prim_path="/World/Robot")
+        robot_cfg.spawn.articulation_props.fix_root_link = False
+        robot = Articulation(cfg=robot_cfg)
+
+        # Check that boundedness of articulation is correct
+        self.assertEqual(ctypes.c_long.from_address(id(robot)).value, 1)
+
+        # Play sim
+        self.sim.reset()
+        # Check if robot is initialized
+        self.assertTrue(robot._is_initialized)
+        # Check that fixed base
+        self.assertFalse(robot.is_fixed_base)
+        # Check buffers that exists and have correct shapes
+        self.assertTrue(robot.data.root_pos_w.shape == (1, 3))
+        self.assertTrue(robot.data.root_quat_w.shape == (1, 4))
+        self.assertTrue(robot.data.joint_pos.shape == (1, 9))
+
+        # Check some internal physx data for debugging
+        # -- joint related
+        self.assertEqual(robot.root_physx_view.max_dofs, robot.root_physx_view.shared_metatype.dof_count)
+        # -- link related
+        self.assertEqual(robot.root_physx_view.max_links, robot.root_physx_view.shared_metatype.link_count)
+        # -- link names (check within articulation ordering is correct)
+        prim_path_body_names = [path.split("/")[-1] for path in robot.root_physx_view.link_paths[0]]
+        self.assertListEqual(prim_path_body_names, robot.body_names)
 
         # Simulate physics
         for _ in range(10):

--- a/source/extensions/omni.isaac.orbit/test/deps/isaacsim/check_floating_base_made_fixed.py
+++ b/source/extensions/omni.isaac.orbit/test/deps/isaacsim/check_floating_base_made_fixed.py
@@ -1,0 +1,157 @@
+# Copyright (c) 2022-2024, The ORBIT Project Developers.
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""This script demonstrates how to make a floating robot fixed in Isaac Sim."""
+
+"""Launch Isaac Sim Simulator first."""
+
+
+import argparse
+
+from omni.isaac.kit import SimulationApp
+
+# add argparse arguments
+parser = argparse.ArgumentParser(
+    description="This script shows the issue in Isaac Sim with making a floating robot fixed."
+)
+parser.add_argument("--headless", action="store_true", help="Run in headless mode.")
+parser.add_argument("--fix-base", action="store_true", help="Whether to fix the base of the robot.")
+# parse the arguments
+args_cli = parser.parse_args()
+
+# launch omniverse app
+simulation_app = SimulationApp({"headless": args_cli.headless})
+
+"""Rest everything follows."""
+
+import torch
+
+import carb
+import omni.isaac.core.utils.nucleus as nucleus_utils
+import omni.isaac.core.utils.prims as prim_utils
+import omni.isaac.core.utils.stage as stage_utils
+from pxr import Sdf, UsdPhysics
+from omni.isaac.core.articulations import ArticulationView
+from omni.isaac.core.utils.carb import set_carb_setting
+from omni.isaac.core.utils.viewports import set_camera_view
+from omni.isaac.core.world import World
+
+# check nucleus connection
+if nucleus_utils.get_assets_root_path() is None:
+    msg = (
+        "Unable to perform Nucleus login on Omniverse. Assets root path is not set.\n"
+        "\tPlease check: https://docs.omniverse.nvidia.com/app_isaacsim/app_isaacsim/overview.html#omniverse-nucleus"
+    )
+    carb.log_error(msg)
+    raise RuntimeError(msg)
+
+
+ISAAC_NUCLEUS_DIR = f"{nucleus_utils.get_assets_root_path()}/Isaac"
+"""Path to the `Isaac` directory on the NVIDIA Nucleus Server."""
+
+ISAAC_ORBIT_NUCLEUS_DIR = f"{nucleus_utils.get_assets_root_path()}/Isaac/Samples/Orbit"
+"""Path to the `Isaac/Samples/Orbit` directory on the NVIDIA Nucleus Server."""
+
+
+"""
+Main
+"""
+
+
+def main():
+    """Spawns the ANYmal robot and makes it fixed."""
+
+    # Load kit helper
+    world = World(physics_dt=0.005, rendering_dt=0.005, backend="torch", device="cuda:0")
+    # Set main camera
+    set_camera_view([2.5, 2.5, 2.5], [0.0, 0.0, 0.0])
+
+    # Enable hydra scene-graph instancing
+    # this is needed to visualize the scene when flatcache is enabled
+    set_carb_setting(world._settings, "/persistent/omnihydra/useSceneGraphInstancing", True)
+
+    # Spawn things into stage
+    # Ground-plane
+    world.scene.add_default_ground_plane(prim_path="/World/defaultGroundPlane", z_position=0.0)
+    # Lights-1
+    prim_utils.create_prim("/World/Light/GreySphere", "SphereLight", translation=(4.5, 3.5, 10.0))
+    # Lights-2
+    prim_utils.create_prim("/World/Light/WhiteSphere", "SphereLight", translation=(-4.5, 3.5, 10.0))
+
+    # -- Robot
+    # resolve asset
+    usd_path = f"{ISAAC_ORBIT_NUCLEUS_DIR}/Robots/ANYbotics/ANYmal-C/anymal_c.usd"
+    root_prim_path = "/World/Robot/base"
+    # add asset
+    print("Loading robot from: ", usd_path)
+    prim_utils.create_prim(
+        "/World/Robot",
+        usd_path=usd_path,
+        translation=(0.0, 0.0, 0.6),
+    )
+    # create fixed joint
+    if args_cli.fix_base:
+        stage = stage_utils.get_current_stage()
+        joint_prim = UsdPhysics.FixedJoint.Define(stage, f"{root_prim_path}/rootJoint")
+        joint_prim.GetJointEnabledAttr().Set(True)
+        joint_prim.CreateBody0Rel().SetTargets([])
+        joint_prim.CreateBody1Rel().SetTargets([Sdf.Path(root_prim_path)])
+
+    # Setup robot
+    robot_view = ArticulationView(root_prim_path, name="ANYMAL")
+    world.scene.add(robot_view)
+    # Play the simulator
+    world.reset()
+
+    # Now we are ready!
+    print("[INFO]: Setup complete...")
+
+    # dummy actions
+    # actions = torch.zeros(robot.count, robot.num_actions, device=robot.device)
+
+    init_root_pos_w, init_root_quat_w = robot_view.get_world_poses()
+    # Define simulation stepping
+    sim_dt = world.get_physics_dt()
+    # episode counter
+    sim_time = 0.0
+    count = 0
+    # Simulate physics
+    while simulation_app.is_running():
+        # If simulation is stopped, then exit.
+        if world.is_stopped():
+            break
+        # If simulation is paused, then skip.
+        if not world.is_playing():
+            world.step(render=False)
+            continue
+        # do reset
+        if count % 20 == 0:
+            # reset
+            sim_time = 0.0
+            count = 0
+            # reset root state
+            root_pos_w = init_root_pos_w.clone()
+            root_pos_w[:, :2] += torch.rand_like(root_pos_w[:, :2]) * 0.5
+            robot_view.set_world_poses(root_pos_w, init_root_quat_w)
+            # print if it is fixed base
+            print("Fixed base: ", robot_view._physics_view.shared_metatype.fixed_base)
+            print("Moving base to: ", root_pos_w[0].cpu().numpy())
+            print("-" * 50)
+
+        # apply random joint actions
+        actions = torch.rand_like(robot_view.get_joint_positions()) * 0.001
+        robot_view.set_joint_efforts(actions)
+        # perform step
+        world.step()
+        # update sim-time
+        sim_time += sim_dt
+        count += 1
+
+
+if __name__ == "__main__":
+    # run the main function
+    main()
+    # close sim app
+    simulation_app.close()

--- a/source/extensions/omni.isaac.orbit/test/deps/isaacsim/check_floating_base_made_fixed.py
+++ b/source/extensions/omni.isaac.orbit/test/deps/isaacsim/check_floating_base_made_fixed.py
@@ -32,13 +32,13 @@ import carb
 import omni.isaac.core.utils.nucleus as nucleus_utils
 import omni.isaac.core.utils.prims as prim_utils
 import omni.isaac.core.utils.stage as stage_utils
-from pxr import Sdf, UsdPhysics
-import omni.physx
 import omni.kit.commands
+import omni.physx
 from omni.isaac.core.articulations import ArticulationView
 from omni.isaac.core.utils.carb import set_carb_setting
 from omni.isaac.core.utils.viewports import set_camera_view
 from omni.isaac.core.world import World
+from pxr import PhysxSchema, UsdPhysics
 
 # check nucleus connection
 if nucleus_utils.get_assets_root_path() is None:
@@ -64,31 +64,6 @@ Main
 
 def main():
     """Spawns the ANYmal robot and makes it fixed."""
-    # -- Robot
-    # resolve asset
-    usd_path = f"{ISAAC_ORBIT_NUCLEUS_DIR}/Robots/ANYbotics/ANYmal-C/anymal_c.usd"
-    root_prim_path = "/World/Robot/base"
-    # add asset
-    print("Loading robot from: ", usd_path)
-    prim_utils.create_prim(
-        "/World/Robot",
-        usd_path=usd_path,
-        translation=(0.0, 0.0, 0.6),
-    )
-    # create fixed joint
-    if args_cli.fix_base:
-        stage = stage_utils.get_current_stage()
-        root_prim = stage.GetPrimAtPath("/World/Robot/base")
-
-        # create fixed joint
-        omni.kit.commands.execute(
-            "CreateJointCommand", stage=stage, joint_type="Fixed", from_prim=None, to_prim=root_prim
-        )
-        # joint_prim = UsdPhysics.FixedJoint.Define(stage, "/World/Robot/rootJoint")
-        # joint_prim.GetJointEnabledAttr().Set(True)
-        # # joint_prim.CreateBody0Rel().SetTargets([])
-        # joint_prim.CreateBody1Rel().SetTargets([root_prim_path])
-
     # Load kit helper
     world = World(physics_dt=0.005, rendering_dt=0.005, backend="torch", device="cpu")
     # Set main camera
@@ -105,8 +80,66 @@ def main():
     prim_utils.create_prim("/World/Light/GreySphere", "SphereLight", translation=(4.5, 3.5, 10.0))
     # Lights-2
     prim_utils.create_prim("/World/Light/WhiteSphere", "SphereLight", translation=(-4.5, 3.5, 10.0))
+    # -- Robot
+    # resolve asset
+    usd_path = f"{ISAAC_ORBIT_NUCLEUS_DIR}/Robots/ANYbotics/ANYmal-C/anymal_c.usd"
+    root_prim_path = "/World/Robot/base"
+    # add asset
+    print("Loading robot from: ", usd_path)
+    prim_utils.create_prim(
+        "/World/Robot",
+        usd_path=usd_path,
+        translation=(0.0, 0.0, 0.6),
+    )
+    # create fixed joint
+    if args_cli.fix_base:
+        # get all necessary information
+        stage = stage_utils.get_current_stage()
+        root_prim = stage.GetPrimAtPath(root_prim_path)
+        parent_prim = root_prim.GetParent()
 
-   
+        # here we assume that the root prim is a rigid body
+        # there is no clear way to deal with situation where the root prim is not a rigid body but has articulation api
+        # in that case, it is unclear how to get the link to the first link in the tree
+        if not root_prim.HasAPI(UsdPhysics.RigidBodyAPI):
+            raise RuntimeError("The root prim does not have the RigidBodyAPI applied.")
+
+        # create fixed joint
+        omni.kit.commands.execute(
+            "CreateJointCommand",
+            stage=stage,
+            joint_type="Fixed",
+            from_prim=None,
+            to_prim=root_prim,
+        )
+
+        # move the root to the parent if this is a rigid body
+        # having a fixed joint on a rigid body makes physx treat it as a part of the maximal coordinate tree
+        # if we put to joint on the parent, physx parser treats it as a fixed base articulation
+        # get parent prim
+        parent_prim = root_prim.GetParent()
+        # apply api to parent
+        UsdPhysics.ArticulationRootAPI.Apply(parent_prim)
+        PhysxSchema.PhysxArticulationAPI.Apply(parent_prim)
+
+        # copy the attributes
+        # -- usd attributes
+        root_usd_articulation_api = UsdPhysics.ArticulationRootAPI(root_prim)
+        for attr_name in root_usd_articulation_api.GetSchemaAttributeNames():
+            attr = root_prim.GetAttribute(attr_name)
+            parent_prim.GetAttribute(attr_name).Set(attr.Get())
+        # -- physx attributes
+        root_physx_articulation_api = PhysxSchema.PhysxArticulationAPI(root_prim)
+        for attr_name in root_physx_articulation_api.GetSchemaAttributeNames():
+            attr = root_prim.GetAttribute(attr_name)
+            parent_prim.GetAttribute(attr_name).Set(attr.Get())
+
+        # remove api from root
+        root_prim.RemoveAPI(UsdPhysics.ArticulationRootAPI)
+        root_prim.RemoveAPI(PhysxSchema.PhysxArticulationAPI)
+
+        # rename root path to parent path
+        root_prim_path = parent_prim.GetPath().pathString
 
     # Setup robot
     robot_view = ArticulationView(root_prim_path, name="ANYMAL")

--- a/source/extensions/omni.isaac.orbit/test/sim/test_schemas.py
+++ b/source/extensions/omni.isaac.orbit/test/sim/test_schemas.py
@@ -118,10 +118,10 @@ class TestPhysicsSchema(unittest.TestCase):
         self._validate_joint_drive_properties_on_prim("/World/asset_instanced")
 
         # make a fixed joint
+        # note: for this asset, it doesn't work because the root is not a rigid body
         self.arti_cfg.fix_root_link = True
-        schemas.modify_articulation_root_properties("/World/asset_instanced", self.arti_cfg)
-        # validate the properties
-        self._validate_articulation_properties_on_prim("/World/asset_instanced", has_default_fixed_root=False)
+        with self.assertRaises(NotImplementedError):
+            schemas.modify_articulation_root_properties("/World/asset_instanced", self.arti_cfg)
 
     def test_modify_properties_on_articulation_usd(self):
         """Test setting properties on articulation usd."""

--- a/source/extensions/omni.isaac.orbit/test/sim/test_utils.py
+++ b/source/extensions/omni.isaac.orbit/test/sim/test_utils.py
@@ -100,6 +100,12 @@ class TestUtilities(unittest.TestCase):
         self.assertIsNotNone(sim_utils.find_global_fixed_joint_prim("/World/Franka"))
         self.assertIsNotNone(sim_utils.find_global_fixed_joint_prim("/World/Franka_Isaac"))
 
+        # make fixed joint disabled manually
+        joint_prim = sim_utils.find_global_fixed_joint_prim("/World/Franka")
+        joint_prim.GetJointEnabledAttr().Set(False)
+        self.assertIsNotNone(sim_utils.find_global_fixed_joint_prim("/World/Franka"))
+        self.assertIsNone(sim_utils.find_global_fixed_joint_prim("/World/Franka", check_enabled_only=True))
+
 
 if __name__ == "__main__":
     run_tests()

--- a/source/extensions/omni.isaac.orbit/test/sim/test_utils.py
+++ b/source/extensions/omni.isaac.orbit/test/sim/test_utils.py
@@ -20,7 +20,7 @@ import omni.isaac.core.utils.prims as prim_utils
 import omni.isaac.core.utils.stage as stage_utils
 
 import omni.isaac.orbit.sim as sim_utils
-from omni.isaac.orbit.utils.assets import ISAAC_ORBIT_NUCLEUS_DIR
+from omni.isaac.orbit.utils.assets import ISAAC_NUCLEUS_DIR, ISAAC_ORBIT_NUCLEUS_DIR
 
 
 class TestUtilities(unittest.TestCase):
@@ -93,10 +93,12 @@ class TestUtilities(unittest.TestCase):
         prim_utils.create_prim(
             "/World/Franka", usd_path=f"{ISAAC_ORBIT_NUCLEUS_DIR}/Robots/FrankaEmika/panda_instanceable.usd"
         )
+        prim_utils.create_prim("/World/Franka_Isaac", usd_path=f"{ISAAC_NUCLEUS_DIR}/Robots/Franka/franka.usd")
 
         # test
         self.assertIsNone(sim_utils.find_global_fixed_joint_prim("/World/ANYmal"))
         self.assertIsNotNone(sim_utils.find_global_fixed_joint_prim("/World/Franka"))
+        self.assertIsNotNone(sim_utils.find_global_fixed_joint_prim("/World/Franka_Isaac"))
 
 
 if __name__ == "__main__":

--- a/source/extensions/omni.isaac.orbit/test/sim/test_utils.py
+++ b/source/extensions/omni.isaac.orbit/test/sim/test_utils.py
@@ -20,6 +20,7 @@ import omni.isaac.core.utils.prims as prim_utils
 import omni.isaac.core.utils.stage as stage_utils
 
 import omni.isaac.orbit.sim as sim_utils
+from omni.isaac.orbit.utils.assets import ISAAC_ORBIT_NUCLEUS_DIR
 
 
 class TestUtilities(unittest.TestCase):
@@ -81,6 +82,21 @@ class TestUtilities(unittest.TestCase):
         # test valid path
         with self.assertRaises(ValueError):
             sim_utils.get_all_matching_child_prims("World/Floor_.*")
+
+    def test_find_global_fixed_joint_prim(self):
+        """Test find_global_fixed_joint_prim() function."""
+        # create scene
+        prim_utils.create_prim("/World")
+        prim_utils.create_prim(
+            "/World/ANYmal", usd_path=f"{ISAAC_ORBIT_NUCLEUS_DIR}/Robots/ANYbotics/ANYmal-C/anymal_c.usd"
+        )
+        prim_utils.create_prim(
+            "/World/Franka", usd_path=f"{ISAAC_ORBIT_NUCLEUS_DIR}/Robots/FrankaEmika/panda_instanceable.usd"
+        )
+
+        # test
+        self.assertIsNone(sim_utils.find_global_fixed_joint_prim("/World/ANYmal"))
+        self.assertIsNotNone(sim_utils.find_global_fixed_joint_prim("/World/Franka"))
 
 
 if __name__ == "__main__":

--- a/source/extensions/omni.isaac.orbit_assets/omni/isaac/orbit_assets/ridgeback_franka.py
+++ b/source/extensions/omni.isaac.orbit_assets/omni/isaac/orbit_assets/ridgeback_franka.py
@@ -20,6 +20,7 @@ from omni.isaac.orbit.utils.assets import ISAAC_NUCLEUS_DIR
 RIDGEBACK_FRANKA_PANDA_CFG = ArticulationCfg(
     spawn=sim_utils.UsdFileCfg(
         usd_path=f"{ISAAC_NUCLEUS_DIR}/Robots/Clearpath/RidgebackFranka/ridgeback_franka.usd",
+        articulation_props=sim_utils.ArticulationRootPropertiesCfg(enabled_self_collisions=False),
         activate_contact_sensors=False,
     ),
     init_state=ArticulationCfg.InitialStateCfg(


### PR DESCRIPTION
# Description

This MR adds an attribute to fix the root link of an articulation. It also fixes the docstrings to mention how to fix a rigid body in the scene.

Fixes #365, #181

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./orbit.sh --format`
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run all the tests with `./orbit.sh --test` and they pass
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there