### PR TITLE
Fixes setup_conda_env: changes 'unalias' to 'unset' for ORBIT_PATH

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -39,6 +39,7 @@ Guidelines for modifications:
 * Jia Lin Yuan
 * Jingzhou Liu
 * Kourosh Darvish
+* Özhan Özen
 * Qinxi Yu
 * René Zurbrügg
 * Ritvik Singh

--- a/orbit.sh
+++ b/orbit.sh
@@ -145,7 +145,7 @@ setup_conda_env() {
     printf '%s\n' '#!/usr/bin/env bash' '' \
         '# for orbit' \
         'unalias orbit &>/dev/null' \
-        'unalias ORBIT_PATH &>/dev/null' \
+        'unset ORBIT_PATH' \
         '' \
         '# for isaac-sim' \
         'unset CARB_APP_PATH' \


### PR DESCRIPTION
# Description

The line `'unalias ORBIT_PATH &>/dev/null'` inside `setup_conda_env()` prevents `orbit.sh --conda` to successfully exit. The "`unset`" command rather than "`unalias`" should be used for environment variables (e.g., `ORBIT_PATH`). This is a problem, e.g., when a custom dockerfile is used to directly install conda during the image build process: the image build process is interrupted.

Fixes #377

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

Before:
https://github.com/NVIDIA-Omniverse/orbit/blob/a642b8e32cf07efa11a583e8db3680d971922e1e/orbit.sh#L148
After:
`'unset ORBIT_PATH' \`

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./orbit.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run all the tests with `./orbit.sh --test` and they pass
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

