### PR TITLE
Fixes parsing of filter prim path expressions in ContactSensor

### DIFF
--- a/source/extensions/omni.isaac.orbit/config/extension.toml
+++ b/source/extensions/omni.isaac.orbit/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.16.1"
+version = "0.16.2"
 
 # Description
 title = "ORBIT framework for Robot Learning"

--- a/source/extensions/omni.isaac.orbit/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.orbit/docs/CHANGELOG.rst
@@ -1,6 +1,17 @@
 Changelog
 ---------
 
+0.16.2 (2024-04-26)
+~~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+* Fixed parsing of filter prim path expressions in the :class:`omni.isaac.orbit.sensors.ContactSensor` class.
+  Earlier, the filter prim paths given to the physics view was not being parsed since they were specified as
+  regex expressions instead of glob expressions.
+
+
 0.16.1 (2024-04-20)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/scene/interactive_scene.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/scene/interactive_scene.py
@@ -16,7 +16,7 @@ from pxr import PhysxSchema
 
 import omni.isaac.orbit.sim as sim_utils
 from omni.isaac.orbit.assets import Articulation, ArticulationCfg, AssetBaseCfg, RigidObject, RigidObjectCfg
-from omni.isaac.orbit.sensors import FrameTransformerCfg, SensorBase, SensorBaseCfg
+from omni.isaac.orbit.sensors import ContactSensorCfg, FrameTransformerCfg, SensorBase, SensorBaseCfg
 from omni.isaac.orbit.terrains import TerrainImporter, TerrainImporterCfg
 
 from .interactive_scene_cfg import InteractiveSceneCfg
@@ -348,6 +348,11 @@ class InteractiveScene:
                         target_frame.prim_path = target_frame.prim_path.format(ENV_REGEX_NS=self.env_regex_ns)
                         updated_target_frames.append(target_frame)
                     asset_cfg.target_frames = updated_target_frames
+                elif isinstance(asset_cfg, ContactSensorCfg):
+                    updated_filter_prim_paths_expr = []
+                    for filter_prim_path in asset_cfg.filter_prim_paths_expr:
+                        updated_filter_prim_paths_expr.append(filter_prim_path.format(ENV_REGEX_NS=self.env_regex_ns))
+                    asset_cfg.filter_prim_paths_expr = updated_filter_prim_paths_expr
 
                 self._sensors[asset_name] = asset_cfg.class_type(asset_cfg)
             elif isinstance(asset_cfg, AssetBaseCfg):

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sensors/contact_sensor/contact_sensor.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sensors/contact_sensor/contact_sensor.py
@@ -245,14 +245,18 @@ class ContactSensor(SensorBase):
                 f"Sensor at path '{self.cfg.prim_path}' could not find any bodies with contact reporter API."
                 "\nHINT: Make sure to enable 'activate_contact_sensors' in the corresponding asset spawn configuration."
             )
+
         # construct regex expression for the body names
         body_names_regex = r"(" + "|".join(body_names) + r")"
         body_names_regex = f"{self.cfg.prim_path.rsplit('/', 1)[0]}/{body_names_regex}"
-        # construct a new regex expression
+        # convert regex expressions to glob expressions for PhysX
+        body_names_glob = body_names_regex.replace(".*", "*")
+        filter_prim_paths_glob = [expr.replace(".*", "*") for expr in self.cfg.filter_prim_paths_expr]
+
         # create a rigid prim view for the sensor
-        self._body_physx_view = self._physics_sim_view.create_rigid_body_view(body_names_regex.replace(".*", "*"))
+        self._body_physx_view = self._physics_sim_view.create_rigid_body_view(body_names_glob)
         self._contact_physx_view = self._physics_sim_view.create_rigid_contact_view(
-            body_names_regex.replace(".*", "*"), filter_patterns=self.cfg.filter_prim_paths_expr
+            body_names_glob, filter_patterns=filter_prim_paths_glob
         )
         # resolve the true count of bodies
         self._num_bodies = self.body_physx_view.count // self._num_envs

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/simulation_cfg.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/simulation_cfg.py
@@ -20,8 +20,8 @@ from .spawners.materials import RigidBodyMaterialCfg
 class PhysxCfg:
     """Configuration for PhysX solver-related parameters.
 
-    These parameters are used to configure the PhysX solver. For more information, see the PhysX 5 SDK
-    documentation.
+    These parameters are used to configure the PhysX solver. For more information, see the `PhysX 5 SDK
+    documentation`_.
 
     PhysX 5 supports GPU-accelerated physics simulation. This is enabled by default, but can be disabled
     through the flag `use_gpu`. Unlike CPU PhysX, the GPU simulation feature is not able to dynamically
@@ -29,8 +29,8 @@ class PhysxCfg:
     for GPU features. If insufficient buffer sizes are provided, the simulation will fail with errors and
     lead to adverse behaviors. The buffer sizes can be adjusted through the `gpu_*` parameters.
 
-    References:
-        * PhysX 5 documentation: https://nvidia-omniverse.github.io/PhysX/
+    .. _PhysX 5 SDK documentation: https://nvidia-omniverse.github.io/PhysX/physx/5.3.1/_api_build/class_px_scene_desc.html
+
     """
 
     use_gpu: bool = True

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/simulation_context.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/simulation_context.py
@@ -19,7 +19,7 @@ import omni.physx
 from omni.isaac.core.simulation_context import SimulationContext as _SimulationContext
 from omni.isaac.core.utils.viewports import set_camera_view
 from omni.isaac.version import get_version
-from pxr import Gf, Usd
+from pxr import Gf, PhysxSchema, Usd, UsdPhysics
 
 from .simulation_cfg import SimulationCfg
 from .spawners import DomeLightCfg, GroundPlaneCfg
@@ -36,7 +36,7 @@ class SimulationContext(_SimulationContext):
     * playing, pausing, stepping and stopping the simulation
     * adding and removing callbacks to different simulation events such as physics stepping, rendering, etc.
 
-    This class inherits from the `omni.isaac.core.simulation_context.SimulationContext`_ class and
+    This class inherits from the :class:`omni.isaac.core.simulation_context.SimulationContext` class and
     adds additional functionalities such as setting up the simulation context with a configuration object,
     exposing other commonly used simulator-related functions, and performing version checks of Isaac Sim
     to ensure compatibility between releases.
@@ -65,8 +65,6 @@ class SimulationContext(_SimulationContext):
     Based on above, for most functions in this class there is an equivalent function that is suffixed
     with ``_async``. The ``_async`` functions are used in the Omniverse extension mode and
     the non-``_async`` functions are used in the standalone python script mode.
-
-    .. _omni.isaac.core.simulation_context.SimulationContext: https://docs.omniverse.nvidia.com/py/isaacsim/source/extensions/omni.isaac.core/docs/index.html#module-omni.isaac.core.simulation_context
     """
 
     class RenderMode(enum.IntEnum):
@@ -503,8 +501,8 @@ class SimulationContext(_SimulationContext):
     def _set_additional_physx_params(self):
         """Sets additional PhysX parameters that are not directly supported by the parent class."""
         # obtain the physics scene api
-        physics_scene = self._physics_context._physics_scene  # pyright: ignore [reportPrivateUsage]
-        physx_scene_api = self._physics_context._physx_scene_api  # pyright: ignore [reportPrivateUsage]
+        physics_scene: UsdPhysics.Scene = self._physics_context._physics_scene
+        physx_scene_api: PhysxSchema.PhysxSceneAPI = self._physics_context._physx_scene_api
         # assert that scene api is not None
         if physx_scene_api is None:
             raise RuntimeError("Physics scene API is None! Please create the scene first.")

--- a/source/extensions/omni.isaac.orbit/test/sensors/test_contact_sensor.py
+++ b/source/extensions/omni.isaac.orbit/test/sensors/test_contact_sensor.py
@@ -256,7 +256,7 @@ class TestContactSensor(unittest.TestCase):
                             track_pose=True,
                             debug_vis=False,
                             update_period=0.0,
-                            filter_prim_paths_expr=["{ENV_REGEX_NS}/Cube_2", "/World/ground"],
+                            filter_prim_paths_expr=["{ENV_REGEX_NS}/Cube_2"],
                         )
                         # -- contact sensor 2
                         scene_cfg.contact_sensor_2 = ContactSensorCfg(


### PR DESCRIPTION
# Description

PhysX view classes expect the expressions to be in "Glob" format instead of "Regex". While we did this conversion for the body views, it was missing for the filter prim paths expressions. This MR fixes this issue.

Fixes https://github.com/NVIDIA-Omniverse/orbit/issues/364

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./orbit.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run all the tests with `./orbit.sh --test` and they pass
- [x] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there