### PR TITLE
Allows setting USD variants on loading from file

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -38,6 +38,7 @@ Guidelines for modifications:
 * Chenyu Yang
 * Jia Lin Yuan
 * Jingzhou Liu
+* Lorenz Wellhausen
 * Muhong Guo
 * Kourosh Darvish
 * Özhan Özen

--- a/source/extensions/omni.isaac.orbit/config/extension.toml
+++ b/source/extensions/omni.isaac.orbit/config/extension.toml
@@ -1,7 +1,7 @@
 [package]
 
 # Note: Semantic Versioning is used: https://semver.org/
-version = "0.16.2"
+version = "0.16.3"
 
 # Description
 title = "ORBIT framework for Robot Learning"

--- a/source/extensions/omni.isaac.orbit/docs/CHANGELOG.rst
+++ b/source/extensions/omni.isaac.orbit/docs/CHANGELOG.rst
@@ -1,6 +1,16 @@
 Changelog
 ---------
 
+0.16.3 (2024-05-13)
+~~~~~~~~~~~~~~~~~~~
+
+Added
+^^^^^
+
+* Added ``variants`` attribute to the :class:`omni.isaac.orbit.sim.from_files.UsdFileCfg` class to select USD
+  variants when loading assets from USD files.
+
+
 0.16.2 (2024-04-26)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/spawners/from_files/from_files.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/spawners/from_files/from_files.py
@@ -14,7 +14,7 @@ import omni.kit.commands
 from pxr import Gf, Sdf, Usd
 
 from omni.isaac.orbit.sim import converters, schemas
-from omni.isaac.orbit.sim.utils import bind_physics_material, bind_visual_material, clone
+from omni.isaac.orbit.sim.utils import bind_physics_material, bind_visual_material, clone, set_usd_variants
 
 if TYPE_CHECKING:
     from . import from_files_cfg
@@ -233,6 +233,9 @@ def _spawn_from_usd_file(
     else:
         carb.log_warn(f"A prim already exists at prim path: '{prim_path}'.")
 
+    # modify variants
+    if cfg.variants is not None:
+        set_usd_variants(prim_path, cfg.variants)
     # modify rigid body properties
     if cfg.rigid_props is not None:
         schemas.modify_rigid_body_properties(prim_path, cfg.rigid_props)

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/spawners/from_files/from_files.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/spawners/from_files/from_files.py
@@ -234,8 +234,9 @@ def _spawn_from_usd_file(
         carb.log_warn(f"A prim already exists at prim path: '{prim_path}'.")
 
     # modify variants
-    if cfg.variants is not None:
+    if hasattr(cfg, "variants") and cfg.variants is not None:
         select_usd_variants(prim_path, cfg.variants)
+
     # modify rigid body properties
     if cfg.rigid_props is not None:
         schemas.modify_rigid_body_properties(prim_path, cfg.rigid_props)

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/spawners/from_files/from_files.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/spawners/from_files/from_files.py
@@ -14,7 +14,7 @@ import omni.kit.commands
 from pxr import Gf, Sdf, Usd
 
 from omni.isaac.orbit.sim import converters, schemas
-from omni.isaac.orbit.sim.utils import bind_physics_material, bind_visual_material, clone, set_usd_variants
+from omni.isaac.orbit.sim.utils import bind_physics_material, bind_visual_material, clone, select_usd_variants
 
 if TYPE_CHECKING:
     from . import from_files_cfg
@@ -235,7 +235,7 @@ def _spawn_from_usd_file(
 
     # modify variants
     if cfg.variants is not None:
-        set_usd_variants(prim_path, cfg.variants)
+        select_usd_variants(prim_path, cfg.variants)
     # modify rigid body properties
     if cfg.rigid_props is not None:
         schemas.modify_rigid_body_properties(prim_path, cfg.rigid_props)

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/spawners/from_files/from_files_cfg.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/spawners/from_files/from_files_cfg.py
@@ -69,6 +69,14 @@ class UsdFileCfg(FileCfg):
     usd_path: str = MISSING
     """Path to the USD file to spawn asset from."""
 
+    variants: object | dict[str, str] | None = None
+    """Variants to apply to the USD file. Defaults to None.
+
+    Can either be a configclass object, in which case each attribute is used as a variant name and value,
+    or a dictionary where the keys are the variant names and the values are the variant values.
+    If None, then no variants are applied.
+    """
+
 
 @configclass
 class UrdfFileCfg(FileCfg, converters.UrdfConverterCfg):

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/spawners/from_files/from_files_cfg.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/spawners/from_files/from_files_cfg.py
@@ -75,6 +75,7 @@ class UsdFileCfg(FileCfg):
     Can either be a configclass object, in which case each attribute is used as a variant name and value,
     or a dictionary where the keys are the variant names and the values are the variant values.
     If None, then no variants are applied.
+    See :meth:`select_usd_variants` for more information.
     """
 
 

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/spawners/from_files/from_files_cfg.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/spawners/from_files/from_files_cfg.py
@@ -70,12 +70,11 @@ class UsdFileCfg(FileCfg):
     """Path to the USD file to spawn asset from."""
 
     variants: object | dict[str, str] | None = None
-    """Variants to apply to the USD file. Defaults to None.
+    """Variants to select from in the input USD file. Defaults to None, in which case no variants are applied.
 
-    Can either be a configclass object, in which case each attribute is used as a variant name and value,
-    or a dictionary where the keys are the variant names and the values are the variant values.
-    If None, then no variants are applied.
-    See :meth:`select_usd_variants` for more information.
+    This can either be a configclass object, in which case each attribute is used as a variant set name and its specified value,
+    or a dictionary mapping between the two. Please check the :meth:`~omni.isaac.orbit.sim.utils.select_usd_variants` function
+    for more information.
     """
 
 

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/utils.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/utils.py
@@ -789,12 +789,23 @@ def set_usd_variants(prim_path: str, variants: object | dict[str, str], stage: U
     Sets the variant selections for the specified variant sets on a USD prim.
 
     Args:
-        prim_path (str): The path of the USD prim.
-        variants (dict[str, str]): A dictionary mapping variant set names to variant selections.
-        stage (Usd.Stage | None, optional): The USD stage. If not provided, the current stage will be used.
+        prim_path: The path of the USD prim.
+        variants: A dictionary or config class mapping variant set names to variant selections.
+                  E.g.:
+                      {
+                          "color": "red",
+                          "size": "large",
+                      }
 
-    Returns:
-        None
+                  - or -
+
+                      @configclass
+                      ConfigClass(
+                          color: Literal["blue","red"] = "red"
+                          size: Literal["small", "large] = "large"
+                      )
+        stage: The USD stage. Defaults to None, in which case, the current stage is used.
+
     """
     if stage is None:
         stage = stage_utils.get_current_stage()
@@ -804,7 +815,7 @@ def set_usd_variants(prim_path: str, variants: object | dict[str, str], stage: U
     existing_variant_sets = prim.GetVariantSets()
 
     # Convert do dict if we have a configclass object.
-    if variants is not isinstance(variants, dict):
+    if not isinstance(variants, dict):
         variants = variants.__dict__
 
     for variant_set_name, variant_selection in variants.items():

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/utils.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/utils.py
@@ -777,3 +777,46 @@ def find_global_fixed_joint_prim(
                 break
 
     return fixed_joint_prim
+
+
+"""
+USD Variants.
+"""
+
+
+def set_usd_variants(
+    prim_path: str, variants: object | dict[str, str], stage: Usd.Stage | None = None
+) -> None:
+    """
+    Sets the variant selections for the specified variant sets on a USD prim.
+
+    Args:
+        prim_path (str): The path of the USD prim.
+        variants (dict[str, str]): A dictionary mapping variant set names to variant selections.
+        stage (Usd.Stage | None, optional): The USD stage. If not provided, the current stage will be used.
+
+    Returns:
+        None
+    """
+    if stage is None:
+        stage = stage_utils.get_current_stage()
+
+    prim = stage.GetPrimAtPath(prim_path)
+
+    existing_variant_sets = prim.GetVariantSets()
+
+    # Convert do dict if we have a configclass object.
+    if variants is not isinstance(variants, dict):
+        variants = variants.__dict__
+
+    for variant_set_name, variant_selection in variants.items():
+        # Check if the variant set exists on the prim.
+        if not existing_variant_sets.HasVariantSet(variant_set_name):
+            carb.log_warn(f"Variant set '{variant_set_name}' does not exist on prim '{prim_path}'.")
+            continue
+
+        variant_set = existing_variant_sets.GetVariantSet(variant_set_name)
+        # Only set the variant selection if it is different from the current selection.
+        if variant_set.GetVariantSelection() != variant_selection:
+            variant_set.SetVariantSelection(variant_selection)
+            carb.log_info(f"Set variant selection '{variant_selection}' for variant set '{variant_set_name}' on prim '{prim_path}'.")

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/utils.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/utils.py
@@ -818,5 +818,6 @@ def set_usd_variants(prim_path: str, variants: object | dict[str, str], stage: U
         if variant_set.GetVariantSelection() != variant_selection:
             variant_set.SetVariantSelection(variant_selection)
             carb.log_info(
-                f"Set variant selection '{variant_selection}' for variant set '{variant_set_name}' on prim '{prim_path}'."
+                f"Set variant selection '{variant_selection}' for variant set '{variant_set_name}' on prim"
+                f" '{prim_path}'."
             )

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/utils.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/utils.py
@@ -784,7 +784,7 @@ USD Variants.
 """
 
 
-def set_usd_variants(prim_path: str, variants: object | dict[str, str], stage: Usd.Stage | None = None) -> None:
+def select_usd_variants(prim_path: str, variants: object | dict[str, str], stage: Usd.Stage | None = None) -> None:
     """
     Sets the variant selections for the specified variant sets on a USD prim.
 

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/utils.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/utils.py
@@ -784,9 +784,7 @@ USD Variants.
 """
 
 
-def set_usd_variants(
-    prim_path: str, variants: object | dict[str, str], stage: Usd.Stage | None = None
-) -> None:
+def set_usd_variants(prim_path: str, variants: object | dict[str, str], stage: Usd.Stage | None = None) -> None:
     """
     Sets the variant selections for the specified variant sets on a USD prim.
 
@@ -819,4 +817,6 @@ def set_usd_variants(
         # Only set the variant selection if it is different from the current selection.
         if variant_set.GetVariantSelection() != variant_selection:
             variant_set.SetVariantSelection(variant_selection)
-            carb.log_info(f"Set variant selection '{variant_selection}' for variant set '{variant_set_name}' on prim '{prim_path}'.")
+            carb.log_info(
+                f"Set variant selection '{variant_selection}' for variant set '{variant_set_name}' on prim '{prim_path}'."
+            )

--- a/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/utils.py
+++ b/source/extensions/omni.isaac.orbit/omni/isaac/orbit/sim/utils.py
@@ -804,6 +804,8 @@ def select_usd_variants(prim_path: str, variants: object | dict[str, str], stage
                           color: Literal["blue","red"] = "red"
                           size: Literal["small", "large] = "large"
                       )
+                  For more information on USD variants, see the official documentation:
+                  https://graphics.pixar.com/usd/docs/USD-Glossary.html#USDGlossary-Variant
         stage: The USD stage. Defaults to None, in which case, the current stage is used.
 
     """

--- a/source/extensions/omni.isaac.orbit/test/sim/test_utils.py
+++ b/source/extensions/omni.isaac.orbit/test/sim/test_utils.py
@@ -22,6 +22,8 @@ import omni.isaac.core.utils.stage as stage_utils
 import omni.isaac.orbit.sim as sim_utils
 from omni.isaac.orbit.utils.assets import ISAAC_NUCLEUS_DIR, ISAAC_ORBIT_NUCLEUS_DIR
 
+from pxr import Usd, UsdGeom, Sdf
+
 
 class TestUtilities(unittest.TestCase):
     """Test fixture for the sim utility functions."""
@@ -106,6 +108,23 @@ class TestUtilities(unittest.TestCase):
         self.assertIsNotNone(sim_utils.find_global_fixed_joint_prim("/World/Franka"))
         self.assertIsNone(sim_utils.find_global_fixed_joint_prim("/World/Franka", check_enabled_only=True))
 
+    def test_select_usd_variants(self):
+        """ Test select_usd_variants() function."""
+        stage = stage_utils.get_current_stage()
+        prim: Usd.Prim = UsdGeom.Xform.Define(stage, Sdf.Path("/World")).GetPrim()
+        stage.SetDefaultPrim(prim)
+
+        # Create the variant set and add your variants to it.
+        variants = ["red", "blue", "green"]
+        variant_set = prim.GetVariantSets().AddVariantSet("colors")
+        for variant in variants:
+            variant_set.AddVariant(variant)
+
+        # Set the variant selection
+        sim_utils.utils.select_usd_variants("/World", {"colors": "red"}, stage)
+
+        # Check if the variant selection is correct
+        self.assertEqual(variant_set.GetVariantSelection(), "red")
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
# Description

This PR introduces a `variants` attribute in the `UsdFileCfg` which can be used to set different variants when loading an asset from a USD file.

- New function `set_usd_variants` which applies variant sets to a prim
- New, optional `variants` attribute in the `UsdFileCfg` to specify the attributes to be set
- Add variant setting in the `_spawn_from_usd_file` function

Fixes #401

## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `./orbit.sh --format`
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run all the tests with `./orbit.sh --test` and they pass
- [ ] I have updated the changelog and the corresponding version in the extension's `config/extension.toml` file
- [x] I have added my name to the `CONTRIBUTORS.md` or my name already exists there
